### PR TITLE
Feat: 시간표 주간 UI 구현 및 주간/월간 라우터 설정

### DIFF
--- a/src/components/HomeLayout/HomeLayout.module.scss
+++ b/src/components/HomeLayout/HomeLayout.module.scss
@@ -4,4 +4,5 @@
 .mainContainer {
   display: flex;
   margin-top: 80px;
+  width: 100dvw;
 }

--- a/src/components/common/TimeTableItem/TimeTableItem.module.scss
+++ b/src/components/common/TimeTableItem/TimeTableItem.module.scss
@@ -1,0 +1,32 @@
+@import '../../../styles/variables/colors.scss';
+@import '../../../styles/variables/fonts.scss';
+
+.scheduleItem {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  position: absolute;
+  width: calc((100% - 30px) / 7);
+  background-color: #d6dfff;
+  left: var(--schedule-left);
+  top: var(--schedule-top);
+  height: var(--schedule-height);
+  padding: 10px;
+  border: 1px solid #0028b6;
+  border-radius: 10px;
+  color: #0028b6;
+}
+.title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.name {
+  @include Medium-Body-18;
+}
+.location {
+  @include Medium-Sub-14;
+}
+.time {
+  @include Medium-Sub-14;
+}

--- a/src/components/common/TimeTableItem/TimeTableItem.tsx
+++ b/src/components/common/TimeTableItem/TimeTableItem.tsx
@@ -1,0 +1,30 @@
+import { IScheduleElement } from '../../../constants/schedule';
+import { getScheduleStyle } from '../../../utils/schedule';
+import styles from './TimeTableItem.module.scss';
+
+const TimeTableItem = ({
+  //id,
+  //scheduleId,
+  name,
+  location,
+  dayOfWeek,
+  startTime,
+  endTime,
+}: IScheduleElement) => {
+  return (
+    <div
+      className={styles.scheduleItem}
+      style={getScheduleStyle(dayOfWeek, startTime, endTime)}
+    >
+      <span className={styles.title}>
+        <h6 className={styles.name}>{name}</h6>
+        <p className={styles.location}>{location}</p>
+      </span>
+      <p
+        className={styles.time}
+      >{`${startTime.slice(11, 16)}~${endTime.slice(11, 16)}`}</p>
+    </div>
+  );
+};
+
+export default TimeTableItem;

--- a/src/components/common/buttons/TabLink/TabLink.tsx
+++ b/src/components/common/buttons/TabLink/TabLink.tsx
@@ -6,16 +6,22 @@ interface IProps {
   activeIcon: React.ReactNode;
   inactiveIcon: React.ReactNode;
   children: React.ReactNode;
+  exact?: boolean;
 }
 
-const TabLink = ({ to, activeIcon, inactiveIcon, children }: IProps) => {
+const TabLink = ({
+  to,
+  activeIcon,
+  inactiveIcon,
+  children,
+  exact = false,
+}: IProps) => {
   const location = useLocation();
-  const isActive = location.pathname === to;
+  const isActive = exact
+    ? location.pathname === to
+    : location.pathname.startsWith(to);
   return (
-    <Link
-      to={to}
-      className={`${styles.navItem} ${isActive ? styles.active : ''}`}
-    >
+    <Link to={to} className={`${styles.navItem} ${isActive && styles.active}`}>
       {isActive ? activeIcon : inactiveIcon}
       <span>{children}</span>
     </Link>

--- a/src/components/headers/MainHeader/MainHeader.module.scss
+++ b/src/components/headers/MainHeader/MainHeader.module.scss
@@ -11,23 +11,23 @@
   height: 80px;
   padding: 20px 40px 20px 20px;
   background-color: white;
+  z-index: 10;
 }
-
 .dropDownsContainer {
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 20px;
   height: 100%;
-  .dropDownBtn {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    gap: 10px;
-    height: 100%;
-    background-color: white;
-    border: none;
-    cursor: pointer;
-    @include Medium-Sub-14;
-  }
+}
+.dropDownBtn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  height: 100%;
+  background-color: white;
+  border: none;
+  cursor: pointer;
+  @include Medium-Sub-14;
 }

--- a/src/components/headers/MainHeader/MainHeader.module.scss
+++ b/src/components/headers/MainHeader/MainHeader.module.scss
@@ -9,7 +9,7 @@
   top: 0;
   width: 100dvw;
   height: 80px;
-  padding: 20px 10px;
+  padding: 20px;
   background-color: white;
 }
 

--- a/src/components/headers/MainHeader/MainHeader.module.scss
+++ b/src/components/headers/MainHeader/MainHeader.module.scss
@@ -9,7 +9,7 @@
   top: 0;
   width: 100dvw;
   height: 80px;
-  padding: 20px;
+  padding: 20px 40px 20px 20px;
   background-color: white;
 }
 

--- a/src/components/navigators/MainNav/MainNav.module.scss
+++ b/src/components/navigators/MainNav/MainNav.module.scss
@@ -30,6 +30,6 @@
 .linksContainer {
   display: flex;
   flex-direction: column;
-  gap: 20px;
-  padding: 0 10px;
+  gap: 30px;
+  padding: 10px;
 }

--- a/src/components/navigators/MainNav/MainNav.module.scss
+++ b/src/components/navigators/MainNav/MainNav.module.scss
@@ -6,14 +6,12 @@
   flex-direction: column;
   gap: 20px;
   width: 240px;
-  padding: 20px;
-  padding-top: 20px;
+  padding: 50px 20px 20px 20px;
 }
 .searchBar {
   display: flex;
   height: 40px;
-  padding: 20px;
-  padding-left: 35px;
+  padding: 20px 20px 20px 35px;
   border: solid 3px $light-bg_E5;
   border-radius: 10px;
   @include Medium-Sub-14;

--- a/src/components/navigators/MainNav/MainNav.tsx
+++ b/src/components/navigators/MainNav/MainNav.tsx
@@ -22,6 +22,7 @@ const MainNav = () => {
           to="/home"
           activeIcon={<MyBoardActive />}
           inactiveIcon={<MyBoardInactive />}
+          exact={true}
         >
           내 보드
         </TabLink>

--- a/src/constants/schedule.ts
+++ b/src/constants/schedule.ts
@@ -1,9 +1,11 @@
+export type DayOfWeek = 'SUN' | 'MON' | 'TUE' | 'WED' | 'THU' | 'FRI' | 'SAT';
+
 export interface IScheduleElement {
   id: number;
   scheduleId: number;
   name: string;
   location: string;
-  dayOfWeek: string;
+  dayOfWeek: DayOfWeek;
   startTime: string;
   endTime: string;
 }

--- a/src/constants/schedule.ts
+++ b/src/constants/schedule.ts
@@ -1,0 +1,77 @@
+export interface IScheduleElement {
+  id: number;
+  scheduleId: number;
+  name: string;
+  location: string;
+  dayOfWeek: string;
+  startTime: string;
+  endTime: string;
+}
+
+export const scheduleElements: IScheduleElement[] = [
+  {
+    id: 1,
+    scheduleId: 7,
+    name: '경제학원론',
+    location: '경영관',
+    dayOfWeek: 'MON',
+    startTime: '2023-06-12T10:00:00.000+00:00',
+    endTime: '2023-06-12T12:00:00.000+00:00',
+  },
+  {
+    id: 2,
+    scheduleId: 7,
+    name: '경제학원론',
+    location: '경영관',
+    dayOfWeek: 'WED',
+    startTime: '2023-06-12T10:00:00.000+00:00',
+    endTime: '2023-06-12T12:00:00.000+00:00',
+  },
+  {
+    id: 5,
+    scheduleId: 7,
+    name: '미시경제학',
+    location: '경영관 301호',
+    dayOfWeek: 'TUE',
+    startTime: '2023-06-13T09:00:00.000+00:00',
+    endTime: '2023-06-13T10:30:00.000+00:00',
+  },
+  {
+    id: 6,
+    scheduleId: 7,
+    name: '거시경제학',
+    location: '사회과학관 201호',
+    dayOfWeek: 'WED',
+    startTime: '2023-06-14T13:00:00.000+00:00',
+    endTime: '2023-06-14T14:30:00.000+00:00',
+  },
+  {
+    id: 7,
+    scheduleId: 7,
+    name: '경제통계학',
+    location: '경상관 402호',
+    dayOfWeek: 'THU',
+    startTime: '2023-06-15T15:00:00.000+00:00',
+    endTime: '2023-06-15T16:30:00.000+00:00',
+  },
+  {
+    id: 8,
+    scheduleId: 7,
+    name: '경제수학',
+    location: '수학관 101호',
+    dayOfWeek: 'WED',
+    startTime: '2023-06-12T13:00:00.000+00:00',
+    endTime: '2023-06-12T14:30:00.000+00:00',
+  },
+  {
+    id: 9,
+    scheduleId: 7,
+    name: '경제학세미나',
+    location: '경영관 세미나실',
+    dayOfWeek: 'FRI',
+    startTime: '2023-06-16T13:00:00.000+00:00',
+    endTime: '2023-06-16T16:00:00.000+00:00',
+  },
+];
+
+export const TIMELIST = Array.from(Array(13), (_, i) => i + 9);

--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,12 @@
   src: url('./assets/fonts/Pretendard-Thin.woff');
 }
 
+/* 전체 스타일 적용 */
 * {
   box-sizing: border-box;
+  -ms-overflow-style: none; /* IE, Edge */
+  scrollbar-width: none; /* Firefox */
+}
+*::-webkit-scrollbar {
+  display: none; /* Chrome, Safari, Opera */
 }

--- a/src/pages/Main/TimeTable/MonthlyTimeTable/MonthlyTimeTable.tsx
+++ b/src/pages/Main/TimeTable/MonthlyTimeTable/MonthlyTimeTable.tsx
@@ -1,0 +1,5 @@
+const MonthlyTimeTable = () => {
+  return <div>MonthlyTimeTable</div>;
+};
+
+export default MonthlyTimeTable;

--- a/src/pages/Main/TimeTable/TimeTable.module.scss
+++ b/src/pages/Main/TimeTable/TimeTable.module.scss
@@ -1,0 +1,47 @@
+@import '../../../styles/variables/colors.scss';
+@import '../../../styles/variables/fonts.scss';
+
+.wholeWrapper {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 10px 30px 10px 20px;
+}
+.headerContainer {
+  display: flex;
+  width: 100%;
+  height: 76px;
+  justify-content: space-between;
+  align-items: center;
+}
+.dateBox {
+  display: flex;
+  gap: 20px;
+}
+.today {
+  @include SemiBold-Title-32;
+}
+.toggleMode {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  @include SemiBold-Body-18;
+  a {
+    text-decoration: none;
+  }
+}
+.activeMode {
+  color: black;
+}
+.inactiveMode {
+  color: $light-gray_9E;
+}
+.addScheduleBtn {
+  padding: 10px 15px;
+  background-color: $dark-font_5A;
+  border: none;
+  border-radius: 8px;
+  color: white;
+  @include SemiBold-Body-16;
+  cursor: pointer;
+}

--- a/src/pages/Main/TimeTable/TimeTable.tsx
+++ b/src/pages/Main/TimeTable/TimeTable.tsx
@@ -1,5 +1,34 @@
+import styles from './TimeTable.module.scss';
+import { Link, Outlet, useLocation } from 'react-router-dom';
+
 const TimeTable = () => {
-  return <div>TimeTable</div>;
+  const location = useLocation();
+  const isWeekly = location.pathname === '/home/time-table';
+  return (
+    <div className={styles.wholeWrapper}>
+      <div className={styles.headerContainer}>
+        <div className={styles.dateBox}>
+          <h3 className={styles.today}>06/28(금)</h3>
+          <div className={styles.toggleMode}>
+            <Link
+              to="/home/time-table"
+              className={`${isWeekly ? styles.activeMode : styles.inactiveMode}`}
+            >
+              주간
+            </Link>
+            <Link
+              to="/home/time-table/monthly"
+              className={`${!isWeekly ? styles.activeMode : styles.inactiveMode}`}
+            >
+              월간
+            </Link>
+          </div>
+        </div>
+        <button className={styles.addScheduleBtn}>일정 추가</button>
+      </div>
+      <Outlet />
+    </div>
+  );
 };
 
 export default TimeTable;

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.module.scss
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.module.scss
@@ -42,7 +42,7 @@
 .temp {
   position: absolute;
   width: calc((100% - 30px) / 7);
-  background-color: aqua;
+  background-color: #d6dfff;
   left: var(--schedule-left);
   top: var(--schedule-top);
   height: var(--schedule-height);

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.module.scss
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.module.scss
@@ -23,7 +23,7 @@
 }
 .timeRow {
   display: flex;
-  align-items: flex-end;
+  align-items: flex-start;
   gap: 10px;
   width: 100%;
   height: 80px;
@@ -41,8 +41,9 @@
 }
 .temp {
   position: absolute;
-  top: 50px;
   width: calc((100% - 30px) / 7);
-  height: 80px;
   background-color: aqua;
+  left: var(--schedule-left);
+  top: var(--schedule-top);
+  height: var(--schedule-height);
 }

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.module.scss
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.module.scss
@@ -1,0 +1,48 @@
+@import '../../../../styles/variables/colors.scss';
+@import '../../../../styles/variables/fonts.scss';
+
+.table {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  width: 100%;
+}
+.dayOfWeekRow {
+  display: flex;
+  justify-content: space-between;
+  width: 100%;
+  height: 50px;
+  padding: 0px 30px 0px 0px;
+  @include Medium-Sub-14;
+}
+.dayOfWeekCell {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex: 1;
+}
+.timeRow {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  width: 100%;
+  height: 80px;
+  hr {
+    flex-grow: 1;
+    margin: 0;
+  }
+}
+.time {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 20px;
+  @include Medium-Sub-14;
+}
+.temp {
+  position: absolute;
+  top: 50px;
+  width: calc((100% - 30px) / 7);
+  height: 80px;
+  background-color: aqua;
+}

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
@@ -1,6 +1,5 @@
 import TimeTableItem from '../../../../components/common/TimeTableItem/TimeTableItem';
 import { TIMELIST, scheduleElements } from '../../../../constants/schedule';
-import { getScheduleStyle } from '../../../../utils/schedule';
 import styles from './WeeklyTimeTable.module.scss';
 
 const WeeklyTimeTable = () => {
@@ -21,13 +20,7 @@ const WeeklyTimeTable = () => {
         </div>
       ))}
       {scheduleElements.map((schedule) => (
-        <div
-          className={styles.temp}
-          key={schedule.id}
-          style={getScheduleStyle(schedule)}
-        >
-          {schedule.name}
-        </div>
+        <TimeTableItem key={schedule.id} {...schedule} />
       ))}
     </div>
   );

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
@@ -1,5 +1,43 @@
+import {
+  IScheduleElement,
+  TIMELIST,
+  scheduleElements,
+} from '../../../../constants/schedule';
+import styles from './WeeklyTimeTable.module.scss';
+
+interface IgroupedByDayOfWeek {
+  [key: string]: IScheduleElement[];
+}
+
 const WeeklyTimeTable = () => {
-  return <div>WeeklyTimeTable</div>;
+  const groupedByDayOfWeek: IgroupedByDayOfWeek = scheduleElements.reduce(
+    (acc, curr) => {
+      acc[curr.dayOfWeek] = acc[curr.dayOfWeek] || [];
+      acc[curr.dayOfWeek].push(curr);
+      return acc;
+    },
+    {} as IgroupedByDayOfWeek,
+  );
+
+  const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
+  return (
+    <div className={styles.table}>
+      <div className={styles.dayOfWeekRow}>
+        {daysOfWeek.map((day) => (
+          <div className={styles.dayOfWeekCell} key={day}>
+            {day}
+          </div>
+        ))}
+      </div>
+      {TIMELIST.map((time) => (
+        <div className={styles.timeRow} key={time}>
+          <hr />
+          <span className={styles.time}>{time}</span>
+        </div>
+      ))}
+      <div className={styles.temp}>테스트</div>
+    </div>
+  );
 };
 
 export default WeeklyTimeTable;

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
@@ -1,0 +1,5 @@
+const WeeklyTimeTable = () => {
+  return <div>WeeklyTimeTable</div>;
+};
+
+export default WeeklyTimeTable;

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
@@ -1,24 +1,9 @@
-import {
-  IScheduleElement,
-  TIMELIST,
-  scheduleElements,
-} from '../../../../constants/schedule';
+import TimeTableItem from '../../../../components/common/TimeTableItem/TimeTableItem';
+import { TIMELIST, scheduleElements } from '../../../../constants/schedule';
+import { getScheduleStyle } from '../../../../utils/schedule';
 import styles from './WeeklyTimeTable.module.scss';
 
-interface IgroupedByDayOfWeek {
-  [key: string]: IScheduleElement[];
-}
-
 const WeeklyTimeTable = () => {
-  const groupedByDayOfWeek: IgroupedByDayOfWeek = scheduleElements.reduce(
-    (acc, curr) => {
-      acc[curr.dayOfWeek] = acc[curr.dayOfWeek] || [];
-      acc[curr.dayOfWeek].push(curr);
-      return acc;
-    },
-    {} as IgroupedByDayOfWeek,
-  );
-
   const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
   return (
     <div className={styles.table}>
@@ -35,7 +20,15 @@ const WeeklyTimeTable = () => {
           <span className={styles.time}>{time}</span>
         </div>
       ))}
-      <div className={styles.temp}>테스트</div>
+      {scheduleElements.map((schedule) => (
+        <div
+          className={styles.temp}
+          key={schedule.id}
+          style={getScheduleStyle(schedule)}
+        >
+          {schedule.name}
+        </div>
+      ))}
     </div>
   );
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,8 @@ import MyBoard from './Main/MyBoard/MyBoard';
 import RecordNote from './Main/RecordNote/RecordNote';
 import TestMake from './Main/TestMake/TestMake';
 import TimeTable from './Main/TimeTable/TimeTable';
+import WeeklyTimeTable from './Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable';
+import MonthlyTimeTable from './Main/TimeTable/MonthlyTimeTable/MonthlyTimeTable';
 
 const router = createBrowserRouter([
   {
@@ -30,6 +32,16 @@ const router = createBrowserRouter([
       {
         path: 'time-table',
         element: <TimeTable />,
+        children: [
+          {
+            path: '',
+            element: <WeeklyTimeTable />,
+          },
+          {
+            path: 'monthly',
+            element: <MonthlyTimeTable />,
+          },
+        ],
       },
     ],
   },

--- a/src/styles/variables/fonts.scss
+++ b/src/styles/variables/fonts.scss
@@ -1,4 +1,4 @@
-@mixin Semibold-Title-32 {
+@mixin SemiBold-Title-32 {
   font-family: 'Pretendard-SemiBold';
   font-size: 32pt;
   letter-spacing: -0.025em;

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -1,0 +1,37 @@
+import { DayOfWeek } from '../constants/schedule';
+
+interface ISchedule {
+  dayOfWeek: DayOfWeek;
+  startTime: string;
+  endTime: string;
+}
+
+const DAYMAP: Record<DayOfWeek, number> = {
+  SUN: 0,
+  MON: 1,
+  TUE: 2,
+  WED: 3,
+  THU: 4,
+  FRI: 5,
+  SAT: 6,
+};
+
+export const getScheduleStyle = ({
+  dayOfWeek,
+  startTime,
+  endTime,
+}: ISchedule) => {
+  const startHour = Number(startTime.slice(11, 13));
+  const startMinute = Number(startTime.slice(14, 16)) / 60;
+  const endHour = Number(endTime.slice(11, 13));
+  const endMinute = Number(endTime.slice(14, 16)) / 60;
+  // return 값
+  const top = (startHour + startMinute - 9) * 80 + 50;
+  const height = (endHour + endMinute - startHour - startMinute) * 80;
+  const left = `calc((100% - 30px) * ${DAYMAP[dayOfWeek]} / 7)`;
+  return {
+    '--schedule-left': left,
+    '--schedule-top': `${top}px`,
+    '--schedule-height': `${height}px`,
+  } as React.CSSProperties;
+};

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -1,11 +1,5 @@
 import { DayOfWeek } from '../constants/schedule';
 
-interface ISchedule {
-  dayOfWeek: DayOfWeek;
-  startTime: string;
-  endTime: string;
-}
-
 const DAYMAP: Record<DayOfWeek, number> = {
   SUN: 0,
   MON: 1,
@@ -16,11 +10,11 @@ const DAYMAP: Record<DayOfWeek, number> = {
   SAT: 6,
 };
 
-export const getScheduleStyle = ({
-  dayOfWeek,
-  startTime,
-  endTime,
-}: ISchedule) => {
+export const getScheduleStyle = (
+  dayOfWeek: DayOfWeek,
+  startTime: string,
+  endTime: string,
+) => {
   const startHour = Number(startTime.slice(11, 13));
   const startMinute = Number(startTime.slice(14, 16)) / 60;
   const endHour = Number(endTime.slice(11, 13));


### PR DESCRIPTION
## 요약 (Summary)

시간표 주간 UI 구현 및 주간/월간 라우터 설정

## 변경 사항 (Changes)

- `utils` 폴더 추가 : 유틸리티 함수 관리
- `constants` 폴더 추가 : 상수 관리
- `components/common/TimeTableItem/TimeTableItem.tsx` 컴포넌트 추가 : 시간표 일정 컴포넌트화
- `constants/shedule.ts`에 있는 상수는 Postman 참고해서 임시로 생성 -> 추후 백엔드 API로 받아온 데이터로 변경 예정
- 시간표 아이템 색상은 임시로 임의로 설정해두었습니다. 추후 일정별 색상은 논의 필요할 것 같습니다.
- 시간표 수평선부분 구현 후 강의정보 박스들은 `position: absolute`로 위치 조정하여 얹혔습니다.

## 리뷰 요구사항

- 주간 시간표 UI만 구현하였습니다. 월간 시간표는 추후 구현 예정입니다.
- 현재 디자인은 디자이너분이 곧 바꿀 예정이라고 하니 참고바랍니다! 현재 피그마에 있는대로 임시로 구현했습니다. 
- 6/28(금) 부분도 현재 하드코딩 되어있습니다. 추후 Date 객체 혹은 Date 라이브러리 이용해서 현재 날짜로 생성 예정입니다. 

## 확인 방법 (선택)

![image](https://github.com/TEAM-Hearus/HEARUS-REACT-FRONTEND/assets/126762806/fa7a3ffa-d548-45b5-9a44-cef080848f39)

