### PR TITLE
Chore: mockAPI 연결 및 환경변수 설정

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm ci && npm run build
+      env:
+        VITE_MOCK_API: ${{ secrets.VITE_MOCK_API }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -6,14 +6,14 @@ on:
   push:
     branches:
       - main
+env:
+  VITE_MOCK_API: ${{ secrets.VITE_MOCK_API }}
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - run: npm ci && npm run build
-      env:
-        VITE_MOCK_API: ${{ secrets.VITE_MOCK_API }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -7,6 +7,8 @@ permissions:
   checks: write
   contents: read
   pull-requests: write
+env:
+  VITE_MOCK_API: ${{ secrets.VITE_MOCK_API }}
 jobs:
   build_and_preview:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
@@ -14,8 +16,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm ci && npm run build
-      env:
-        VITE_MOCK_API: ${{ secrets.VITE_MOCK_API }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: npm ci && npm run build
+      env:
+        VITE_MOCK_API: ${{ secrets.VITE_MOCK_API }}
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ dist
 dist-ssr
 *.local
 
+.env
+
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "hearus-react-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.50.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.24.0",
         "styled-reset": "^4.5.2"
       },
       "devDependencies": {
+        "@tanstack/react-query-devtools": "^5.50.1",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
         "@typescript-eslint/eslint-plugin": "^7.13.1",
@@ -1703,6 +1705,57 @@
       "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.50.1.tgz",
+      "integrity": "sha512-lpfhKPrJlyV2DSVcQb/HuozH3Av3kws4ge22agx+lNGpFkS4vLZ7St0l3GLwlAD+bqB+qXGex3JdRKUNtMviEQ==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.50.1.tgz",
+      "integrity": "sha512-MQ5JK3yRwBP1SRuwoJVPGZP4cMLXCQ0t+6blDbcAVGEoqrEuvbgTdwlN729AKBR0hidOWPFR9n5YpI2Y8bBZOQ==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.50.1.tgz",
+      "integrity": "sha512-s0DW3rVBDPReDDovUjVqItVa3R2nPfUANK9nqGvarO2DwTiY9U4EBTsqizMxItRCoGgK5apeM7D3mxlHrSKpdQ==",
+      "dependencies": {
+        "@tanstack/query-core": "5.50.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.50.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.50.1.tgz",
+      "integrity": "sha512-zgPmEFv9GhLAx6eaf9r0ACbcxit1ZSuv/uPpOXBTTSPLijlWcfpQTOdZx0jYQ14t2cUfWjrAW41cUmcCvT4X/g==",
+      "dev": true,
+      "dependencies": {
+        "@tanstack/query-devtools": "5.50.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.50.1",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@types/estree": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,14 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.50.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.24.0",
     "styled-reset": "^4.5.2"
   },
   "devDependencies": {
+    "@tanstack/react-query-devtools": "^5.50.1",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
     "@typescript-eslint/eslint-plugin": "^7.13.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,17 @@
 import { Reset } from 'styled-reset';
 import Router from './pages';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+
+const queryClient = new QueryClient();
 
 function App() {
   return (
-    <>
+    <QueryClientProvider client={queryClient}>
       <Reset />
       <Router />
-    </>
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
   );
 }
 

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,0 +1,3 @@
+const mockAPI_URL: string = import.meta.env.VITE_MOCK_API;
+
+export default mockAPI_URL;

--- a/src/apis/schedule.ts
+++ b/src/apis/schedule.ts
@@ -1,0 +1,26 @@
+import mockAPI_URL from '.';
+import { IScheduleElement } from '../constants/schedule';
+
+interface IGetScheduleResponse {
+  status: string;
+  msg: string;
+  object: {
+    id: number;
+    scheduleElements: IScheduleElement[];
+    name: string;
+    userId: string | null;
+  };
+  success: boolean;
+}
+
+export const getSchedule = async (
+  name: string,
+): Promise<IScheduleElement[]> => {
+  try {
+    const res = await fetch(`${mockAPI_URL}/schedule/getSchedule?name=${name}`);
+    const data: IGetScheduleResponse = await res.json();
+    return data.object['scheduleElements'];
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
@@ -1,9 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
 import TimeTableItem from '../../../../components/common/TimeTableItem/TimeTableItem';
-import { TIMELIST, scheduleElements } from '../../../../constants/schedule';
+import { IScheduleElement, TIMELIST } from '../../../../constants/schedule';
 import styles from './WeeklyTimeTable.module.scss';
+import { getSchedule } from '../../../../apis/schedule';
+
+const name = '건국대학교 3-1학기'; // 임시 지정
 
 const WeeklyTimeTable = () => {
   const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
+  const { data } = useQuery<IScheduleElement[], Error>({
+    queryKey: ['schedule', name],
+    queryFn: () => getSchedule(name),
+  });
   return (
     <div className={styles.table}>
       <div className={styles.dayOfWeekRow}>
@@ -19,7 +27,7 @@ const WeeklyTimeTable = () => {
           <span className={styles.time}>{time}</span>
         </div>
       ))}
-      {scheduleElements.map((schedule) => (
+      {data?.map((schedule) => (
         <TimeTableItem key={schedule.id} {...schedule} />
       ))}
     </div>


### PR DESCRIPTION
## 요약 (Summary)

mockAPI 연결 및 환경변수 설정

## 변경 사항 (Changes)

- mockAPI 환경변수 설정 & 깃허브 secrets에 VITE_MOCK_API 추가
- @tanstack/react-query 설치
- yml 파일에 env 설정 추가
- 시간표 목록 mockAPI에서 받아온 데이터로 연결
- `apis` 폴더 추가 - https 통신 async 함수 관리 

## 리뷰 요구사항

- 루트 디렉토리에 .env 파일 추가하고 `VITE_MOCK_API=mockAPI 공동 URL` 입력하시면 됩니다.
- apis에 fetch 함수 작성 후 사용하고자 하는 파일에서 import 하여 useQuery의 queryFn으로 사용하시면 됩니다.
- env 추가할 일 있을때 깃허브 secrets에 추가하고 yml 파일들에서 `env:` 부분에 추가하시면 됩니다. 환경변수 이름은 `VITE_`로 시작해야합니다. 
```
env:
  VITE_MOCK_API: ${{ secrets.VITE_MOCK_API }}
  VITE_EXAMPLE_NAME: ${{ secrets.VITE_EXAMPLE_NAME }} // 이런 식으로 추가
```

## 확인 방법 (선택)


