### PR TITLE
Feat: 녹음 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.24.0",
+        "socket.io-client": "^4.7.5",
         "styled-reset": "^4.5.2"
       },
       "devDependencies": {
@@ -1281,6 +1282,11 @@
         "win32"
       ]
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA=="
+    },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@svgr/babel-plugin-add-jsx-attribute/-/babel-plugin-add-jsx-attribute-8.0.0.tgz",
@@ -2359,7 +2365,6 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
       "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
-      "dev": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2417,6 +2422,26 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.812.tgz",
       "integrity": "sha512-7L8fC2Ey/b6SePDFKR2zHAy4mbdp1/38Yk5TsARO66W3hC5KEaeKMMHoxwtuH+jcu2AYLSn9QX04i95t6Fl1Hg==",
       "dev": true
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.5.4.tgz",
+      "integrity": "sha512-GeZeeRjpD2qf49cZQ0Wvh/8NJNfeXkXXcoGh+F77oEAgo9gUHwT1fCRxSNU+YEEaysOJTnsFHmM5oAcPy4ntvQ==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1",
+        "xmlhttprequest-ssl": "~2.0.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
     },
     "node_modules/entities": {
       "version": "4.5.0",
@@ -3253,8 +3278,7 @@
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -3770,6 +3794,32 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.7.5",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
+      "integrity": "sha512-sJ/tqHOCe7Z50JCBCXrsY3I2k03iOiUe+tj1OmKeD2lXPiGH/RUCdTZFoqVyN7l1MnpIzPrGtLcijffmeouNlQ==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.2",
+        "engine.io-client": "~6.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
@@ -4090,6 +4140,34 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.0.0.tgz",
+      "integrity": "sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.24.0",
+    "socket.io-client": "^4.7.5",
     "styled-reset": "^4.5.2"
   },
   "devDependencies": {

--- a/src/apis/record.ts
+++ b/src/apis/record.ts
@@ -1,0 +1,3 @@
+const SOCKETURL = import.meta.env.VITE_SOCKETIO_HOST;
+
+export default SOCKETURL;

--- a/src/assets/images/arrow/back.svg
+++ b/src/assets/images/arrow/back.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M11 5.5L4 12M4 12L11 18.5M4 12H20" stroke="#818492" stroke-width="2"/>
+</svg>

--- a/src/components/headers/RecordHeader/RecordHeader.tsx
+++ b/src/components/headers/RecordHeader/RecordHeader.tsx
@@ -1,10 +1,38 @@
 import styles from './Recordheader.module.scss';
 import Back from '../../../assets/images/arrow/back.svg?react';
 import { Link } from 'react-router-dom';
+import { useEffect, useRef, useState } from 'react';
+import { formatTime } from '../../../utils/record';
 
 const RECORD_TITLE = '새로운 녹음-240711';
 
 const RecordHeader = () => {
+  const [seconds, setSeconds] = useState(0);
+  const intervalRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    startTimer();
+    return () => stopTimer();
+  }, []);
+
+  const startTimer = () => {
+    if (intervalRef.current !== null) return;
+    intervalRef.current = setInterval(() => {
+      setSeconds((prev) => prev + 1);
+    }, 1000);
+  };
+
+  const stopTimer = () => {
+    if (intervalRef.current === null) return;
+    clearInterval(intervalRef.current);
+    intervalRef.current = null;
+  };
+
+  const handleOnClickQuitBtn = () => {
+    stopTimer();
+    setSeconds(0);
+  };
+
   return (
     <header className={styles.container}>
       <Link to="/home">
@@ -15,8 +43,10 @@ const RecordHeader = () => {
         <button className={styles.tagBtn}>태그</button>
       </div>
       <div className={styles.timerContainer}>
-        <p className={styles.timer}>{'00:00:00'}</p>
-        <button className={styles.quitBtn}>종료</button>
+        <p className={styles.timer}>{formatTime(seconds)}</p>
+        <button className={styles.quitBtn} onClick={handleOnClickQuitBtn}>
+          종료
+        </button>
       </div>
     </header>
   );

--- a/src/components/headers/RecordHeader/RecordHeader.tsx
+++ b/src/components/headers/RecordHeader/RecordHeader.tsx
@@ -1,0 +1,25 @@
+import styles from './Recordheader.module.scss';
+import Back from '../../../assets/images/arrow/back.svg?react';
+import { Link } from 'react-router-dom';
+
+const RECORD_TITLE = '새로운 녹음-240711';
+
+const RecordHeader = () => {
+  return (
+    <header className={styles.container}>
+      <Link to="/home">
+        <Back />
+      </Link>
+      <div className={styles.titleContainer}>
+        <h1 className={styles.title}>{RECORD_TITLE}</h1>
+        <button className={styles.tagBtn}>태그</button>
+      </div>
+      <div className={styles.timerContainer}>
+        <p className={styles.timer}>{'00:00:00'}</p>
+        <button className={styles.quitBtn}>종료</button>
+      </div>
+    </header>
+  );
+};
+
+export default RecordHeader;

--- a/src/components/headers/RecordHeader/RecordHeader.tsx
+++ b/src/components/headers/RecordHeader/RecordHeader.tsx
@@ -4,11 +4,15 @@ import { Link } from 'react-router-dom';
 import { useEffect, useRef, useState } from 'react';
 import { formatTime } from '../../../utils/record';
 
+interface IProps {
+  handleQuit: () => void;
+}
+
 const RECORD_TITLE = '새로운 녹음-240711';
 
-const RecordHeader = () => {
+const RecordHeader = ({ handleQuit }: IProps) => {
   const [seconds, setSeconds] = useState(0);
-  const intervalRef = useRef<number | null>(null);
+  const timerIntervalRef = useRef<number | null>(null);
 
   useEffect(() => {
     startTimer();
@@ -16,21 +20,22 @@ const RecordHeader = () => {
   }, []);
 
   const startTimer = () => {
-    if (intervalRef.current !== null) return;
-    intervalRef.current = setInterval(() => {
+    if (timerIntervalRef.current !== null) return;
+    timerIntervalRef.current = setInterval(() => {
       setSeconds((prev) => prev + 1);
     }, 1000);
   };
 
   const stopTimer = () => {
-    if (intervalRef.current === null) return;
-    clearInterval(intervalRef.current);
-    intervalRef.current = null;
+    if (timerIntervalRef.current === null) return;
+    clearInterval(timerIntervalRef.current);
+    timerIntervalRef.current = null;
   };
 
   const handleOnClickQuitBtn = () => {
     stopTimer();
     setSeconds(0);
+    handleQuit();
   };
 
   return (

--- a/src/components/headers/RecordHeader/Recordheader.module.scss
+++ b/src/components/headers/RecordHeader/Recordheader.module.scss
@@ -1,0 +1,56 @@
+@import '../../../styles/variables/colors.scss';
+@import '../../../styles/variables/fonts.scss';
+
+.container {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  position: fixed;
+  top: 0;
+  width: 100dvw;
+  height: 70px;
+  background-color: white;
+  z-index: 10;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+.titleContainer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.title {
+  @include Medium_Body_18;
+  color: $dark-font_5A;
+}
+.tagBtn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 5px 10px;
+  background-color: white;
+  @include SemiBold_Sub_14;
+  color: $light-gray_81;
+  border: 1px solid $light-bg_E5;
+  border-radius: 8px;
+}
+.timerContainer {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.timer {
+  @include Medium_Sub_14;
+  color: $dark-font_5A;
+}
+.quitBtn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 10px 20px;
+  background-color: #333333;
+  border: none;
+  border-radius: 24px;
+  @include SemiBold_Body_16;
+  color: white;
+  cursor: pointer;
+}

--- a/src/components/headers/RecordHeader/Recordheader.module.scss
+++ b/src/components/headers/RecordHeader/Recordheader.module.scss
@@ -3,18 +3,24 @@
 
 .container {
   display: flex;
-  justify-content: space-around;
+  justify-content: space-between;
   align-items: center;
   position: fixed;
   top: 0;
   width: 100dvw;
   height: 70px;
+  padding: 0 100px;
   background-color: white;
   z-index: 10;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+  a {
+    display: flex;
+    width: 200px;
+  }
 }
 .titleContainer {
   display: flex;
+  justify-content: center;
   align-items: center;
   gap: 10px;
 }
@@ -35,8 +41,10 @@
 }
 .timerContainer {
   display: flex;
+  justify-content: flex-end;
   align-items: center;
   gap: 10px;
+  width: 200px;
 }
 .timer {
   @include Medium_Sub_14;

--- a/src/hooks/useRecorder.ts
+++ b/src/hooks/useRecorder.ts
@@ -1,0 +1,70 @@
+import { useRef, useEffect } from 'react';
+
+export const useRecorder = (onAudioData: (data: string) => void) => {
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const intervalRef = useRef<number | null>(null);
+
+  const initMediaRecorder = (stream: MediaStream) => {
+    const options = { mimeType: 'audio/webm;codecs=opus' };
+    mediaRecorderRef.current = new MediaRecorder(stream, options);
+
+    mediaRecorderRef.current.ondataavailable = (event) => {
+      if (event.data.size > 0 && event.data != null) {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const arrayBuffer = e.target?.result as ArrayBuffer;
+          if (arrayBuffer) {
+            const base64EncodedData = btoa(
+              String.fromCharCode(...new Uint8Array(arrayBuffer)),
+            );
+            onAudioData(base64EncodedData);
+          } else {
+            console.error(
+              '[mediaRecorder]-[ondataavailable] ArrayBuffer is null',
+            );
+          }
+        };
+        reader.readAsArrayBuffer(event.data);
+      }
+    };
+
+    mediaRecorderRef.current.start(1000);
+  };
+
+  const startRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      initMediaRecorder(stream);
+
+      intervalRef.current = setInterval(() => {
+        if (mediaRecorderRef.current?.state === 'recording') {
+          mediaRecorderRef.current.stop();
+        }
+        initMediaRecorder(stream);
+      }, 5000);
+    } catch (error) {
+      console.error('Error accessing the microphone', error);
+    }
+  };
+
+  const stopRecording = () => {
+    if (mediaRecorderRef.current?.state === 'recording') {
+      mediaRecorderRef.current.stop();
+    }
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+  };
+
+  useEffect(() => {
+    startRecording();
+    return () => {
+      stopRecording();
+    };
+  }, []);
+
+  return { stopRecording };
+};

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -1,0 +1,35 @@
+import { useEffect, useRef } from 'react';
+import { io, Socket } from 'socket.io-client';
+import SOCKETURL from '../apis/record';
+
+export const useSocket = (onTransitionResult: (result: string) => void) => {
+  const socketRef = useRef<Socket | null>(null);
+
+  useEffect(() => {
+    socketRef.current = io(SOCKETURL, {
+      path: '/socket.io',
+      transports: ['websocket'],
+      extraHeaders: {
+        'Sec-WebSocket-Extensions':
+          'permessage-deflate; client_max_window_bits',
+      },
+      reconnection: true,
+      reconnectionDelay: 5000,
+      reconnectionAttempts: Infinity,
+    });
+
+    socketRef.current.on('connect', () => {
+      console.log('socket connected');
+      const lectureId = '668cceb8ebef2b4462de0fb5';
+      socketRef.current?.emit('lectureId', lectureId);
+    });
+
+    socketRef.current.on('transitionResult', onTransitionResult);
+
+    return () => {
+      socketRef.current?.disconnect();
+    };
+  }, [onTransitionResult]);
+
+  return socketRef;
+};

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,5 @@
-import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-);
+ReactDOM.createRoot(document.getElementById('root')!).render(<App />);

--- a/src/pages/PrivateRoute.tsx
+++ b/src/pages/PrivateRoute.tsx
@@ -1,0 +1,15 @@
+import { Navigate } from 'react-router-dom';
+import { checkAuthentication } from '../utils/auth';
+
+interface IProps {
+  element: React.ReactElement;
+}
+
+const PrivateRoute = ({ element }: IProps) => {
+  // 로그인 상태 확인
+  const isAuthenticated = checkAuthentication();
+
+  return isAuthenticated ? element : <Navigate to="/" replace />;
+};
+
+export default PrivateRoute;

--- a/src/pages/Record/Record.module.scss
+++ b/src/pages/Record/Record.module.scss
@@ -1,0 +1,20 @@
+@import '../../styles/variables/colors.scss';
+@import '../../styles/variables/fonts.scss';
+
+.container {
+  display: flex;
+  justify-content: center;
+  width: 100dvw;
+  min-height: 100dvh;
+  background-color: $light-bg_F2;
+}
+.captionContainer {
+  display: flex;
+  width: 60%;
+  padding: 50px;
+  margin-top: 100px;
+  background-color: white;
+  border: none;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+}

--- a/src/pages/Record/Record.module.scss
+++ b/src/pages/Record/Record.module.scss
@@ -17,4 +17,6 @@
   border: none;
   border-top-left-radius: 12px;
   border-top-right-radius: 12px;
+  @include Regular_Body_18_200;
+  color: #333333;
 }

--- a/src/pages/Record/Record.tsx
+++ b/src/pages/Record/Record.tsx
@@ -1,11 +1,115 @@
+import { io, Socket } from 'socket.io-client';
 import RecordHeader from '../../components/headers/RecordHeader/RecordHeader';
 import styles from './Record.module.scss';
+import SOCKETURL from '../../apis/record';
+import { useEffect, useRef, useState } from 'react';
 
 const Record = () => {
+  const [recognitionResult, setRecognitionResult] = useState('');
+  const socketRef = useRef<Socket | null>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const intervalRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    socketRef.current = io(SOCKETURL, {
+      path: '/socket.io',
+      transports: ['websocket'],
+      extraHeaders: {
+        'Sec-WebSocket-Extensions':
+          'permessage-deflate; client_max_window_bits',
+      },
+      reconnection: true,
+      reconnectionDelay: 5000,
+      reconnectionAttempts: Infinity,
+    });
+
+    socketRef.current.on('connect', () => {
+      console.log('socket connected');
+      const lectureId = '668cceb8ebef2b4462de0fb5';
+      socketRef.current?.emit('lectureId', lectureId);
+    });
+
+    socketRef.current.on('transitionResult', (result) => {
+      console.log('transitionResult: ', result);
+      setRecognitionResult((prev) => prev + ' ' + result);
+    });
+
+    // 녹음 시작
+    startRecording();
+
+    return () => {
+      stopRecording();
+      socketRef.current?.disconnect();
+    };
+  }, []);
+
+  const initMediaRecorder = (stream: MediaStream) => {
+    const options = { mimeType: 'audio/webm;codecs=opus' };
+    mediaRecorderRef.current = new MediaRecorder(stream, options);
+
+    mediaRecorderRef.current.ondataavailable = (event) => {
+      if (event.data.size > 0 && event.data != null) {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+          const arrayBuffer = e.target?.result as ArrayBuffer;
+          if (arrayBuffer) {
+            const base64EncodedData = btoa(
+              String.fromCharCode(...new Uint8Array(arrayBuffer)),
+            );
+            socketRef.current?.emit('transcription', base64EncodedData);
+          } else {
+            console.error(
+              '[mediaRecorder]-[ondataavailable] ArrayBuffer is null',
+            );
+          }
+        };
+        reader.readAsArrayBuffer(event.data);
+      }
+    };
+
+    mediaRecorderRef.current.start(1000); // 1초마다 데이터 전송
+  };
+
+  const startRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      streamRef.current = stream;
+      initMediaRecorder(stream);
+
+      // 5초마다 MediaRecorder 재시작
+      intervalRef.current = setInterval(() => {
+        if (mediaRecorderRef.current?.state === 'recording') {
+          mediaRecorderRef.current.stop();
+        }
+        initMediaRecorder(stream);
+      }, 5000);
+    } catch (error) {
+      console.error('Error accessing the microphone', error);
+    }
+  };
+
+  const stopRecording = () => {
+    if (mediaRecorderRef.current?.state === 'recording') {
+      mediaRecorderRef.current.stop();
+    }
+    streamRef.current?.getTracks().forEach((track) => track.stop());
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+    }
+  };
+
+  const handleQuit = () => {
+    // 녹음 중지
+    stopRecording();
+    // 소켓 연결 해제
+    socketRef.current?.disconnect();
+  };
+
   return (
     <div className={styles.container}>
-      <RecordHeader />
-      <article className={styles.captionContainer}></article>
+      <RecordHeader handleQuit={handleQuit} />
+      <article className={styles.captionContainer}>{recognitionResult}</article>
     </div>
   );
 };

--- a/src/pages/Record/Record.tsx
+++ b/src/pages/Record/Record.tsx
@@ -1,110 +1,32 @@
-import { io, Socket } from 'socket.io-client';
+import { useState, useCallback } from 'react';
 import RecordHeader from '../../components/headers/RecordHeader/RecordHeader';
 import styles from './Record.module.scss';
-import SOCKETURL from '../../apis/record';
-import { useEffect, useRef, useState } from 'react';
+import { useSocket } from '../../hooks/useSocket';
+import { useRecorder } from '../../hooks/useRecorder';
 
 const Record = () => {
   const [recognitionResult, setRecognitionResult] = useState('');
-  const socketRef = useRef<Socket | null>(null);
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
-  const streamRef = useRef<MediaStream | null>(null);
-  const intervalRef = useRef<number | null>(null);
 
-  useEffect(() => {
-    socketRef.current = io(SOCKETURL, {
-      path: '/socket.io',
-      transports: ['websocket'],
-      extraHeaders: {
-        'Sec-WebSocket-Extensions':
-          'permessage-deflate; client_max_window_bits',
-      },
-      reconnection: true,
-      reconnectionDelay: 5000,
-      reconnectionAttempts: Infinity,
-    });
-
-    socketRef.current.on('connect', () => {
-      console.log('socket connected');
-      const lectureId = '668cceb8ebef2b4462de0fb5';
-      socketRef.current?.emit('lectureId', lectureId);
-    });
-
-    socketRef.current.on('transitionResult', (result) => {
-      console.log('transitionResult: ', result);
-      setRecognitionResult((prev) => prev + ' ' + result);
-    });
-
-    // 녹음 시작
-    startRecording();
-
-    return () => {
-      stopRecording();
-      socketRef.current?.disconnect();
-    };
+  const onTransitionResult = useCallback((result: string) => {
+    console.log('transitionResult: ', result);
+    setRecognitionResult((prev) => prev + ' ' + result);
   }, []);
 
-  const initMediaRecorder = (stream: MediaStream) => {
-    const options = { mimeType: 'audio/webm;codecs=opus' };
-    mediaRecorderRef.current = new MediaRecorder(stream, options);
+  const socketRef = useSocket(onTransitionResult);
 
-    mediaRecorderRef.current.ondataavailable = (event) => {
-      if (event.data.size > 0 && event.data != null) {
-        const reader = new FileReader();
-        reader.onload = (e) => {
-          const arrayBuffer = e.target?.result as ArrayBuffer;
-          if (arrayBuffer) {
-            const base64EncodedData = btoa(
-              String.fromCharCode(...new Uint8Array(arrayBuffer)),
-            );
-            socketRef.current?.emit('transcription', base64EncodedData);
-          } else {
-            console.error(
-              '[mediaRecorder]-[ondataavailable] ArrayBuffer is null',
-            );
-          }
-        };
-        reader.readAsArrayBuffer(event.data);
-      }
-    };
+  const onAudioData = useCallback(
+    (data: string) => {
+      socketRef.current?.emit('transcription', data);
+    },
+    [socketRef],
+  );
 
-    mediaRecorderRef.current.start(1000); // 1초마다 데이터 전송
-  };
+  const { stopRecording } = useRecorder(onAudioData);
 
-  const startRecording = async () => {
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      streamRef.current = stream;
-      initMediaRecorder(stream);
-
-      // 5초마다 MediaRecorder 재시작
-      intervalRef.current = setInterval(() => {
-        if (mediaRecorderRef.current?.state === 'recording') {
-          mediaRecorderRef.current.stop();
-        }
-        initMediaRecorder(stream);
-      }, 5000);
-    } catch (error) {
-      console.error('Error accessing the microphone', error);
-    }
-  };
-
-  const stopRecording = () => {
-    if (mediaRecorderRef.current?.state === 'recording') {
-      mediaRecorderRef.current.stop();
-    }
-    streamRef.current?.getTracks().forEach((track) => track.stop());
-    if (intervalRef.current) {
-      clearInterval(intervalRef.current);
-    }
-  };
-
-  const handleQuit = () => {
-    // 녹음 중지
+  const handleQuit = useCallback(() => {
     stopRecording();
-    // 소켓 연결 해제
     socketRef.current?.disconnect();
-  };
+  }, [stopRecording, socketRef]);
 
   return (
     <div className={styles.container}>

--- a/src/pages/Record/Record.tsx
+++ b/src/pages/Record/Record.tsx
@@ -1,0 +1,13 @@
+import RecordHeader from '../../components/headers/RecordHeader/RecordHeader';
+import styles from './Record.module.scss';
+
+const Record = () => {
+  return (
+    <div className={styles.container}>
+      <RecordHeader />
+      <article className={styles.captionContainer}></article>
+    </div>
+  );
+};
+
+export default Record;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -7,6 +7,8 @@ import WeeklyTimeTable from './Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable';
 import MonthlyTimeTable from './Main/TimeTable/MonthlyTimeTable/MonthlyTimeTable';
 import MyScript from './Main/MyScript/MyScript';
 import TrashCan from './Main/TrashCan/TrashCan';
+import PrivateRoute from './PrivateRoute';
+import Record from './Record/Record';
 
 const router = createBrowserRouter([
   {
@@ -15,7 +17,7 @@ const router = createBrowserRouter([
   },
   {
     path: '/home',
-    element: <HomeLayout />,
+    element: <PrivateRoute element={<HomeLayout />} />,
     children: [
       {
         path: '',
@@ -44,6 +46,10 @@ const router = createBrowserRouter([
         element: <TrashCan />,
       },
     ],
+  },
+  {
+    path: '/record',
+    element: <PrivateRoute element={<Record />} />,
   },
 ]);
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,3 @@
+export const checkAuthentication = () => {
+  return true; //임시로 로그인 체크 허용
+};

--- a/src/utils/record.ts
+++ b/src/utils/record.ts
@@ -1,0 +1,7 @@
+export const formatTime = (totalSeconds: number) => {
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  return [hours, minutes, seconds].map((v) => (v < 10 ? '0' + v : v)).join(':');
+};


### PR DESCRIPTION
## 요약 (Summary)

녹음 페이지 구현

## 변경 사항 (Changes)

- `/record` 경로에 녹음 페이지 라우터 추가
- `hooks` 폴더 추가 -> `useSocket`, `useRecord` 커스텀 훅 추가
- `PrivateRoute` 추가 : 로그인 여부에 따른 분기 생성 (임시로 true로 설정했으나 로그인 여부 로직은 추후 구현 필요)
- 녹음 종료 버튼을 눌러도 브라우저 탭에서 마이크 사용중 아이콘이 사라지지 않는 버그가 생겨서 `React.StrictMode`를 제거해서 해결했습니다. 현재로서는 제가 알아본 모든 방법을 써도 React.StrictMode가 있으면 해결이 불가능합니다 ㅠ 

## 리뷰 요구사항

- 현재는 socket을 돌리려면 로컬에서 node express 서버를 켜야합니다.
- node 서버 돌리려면 `.env`에 `VITE_SOCKETIO_HOST=http://localhost:3000` 추가 필요합니다.
- `React.StrictMode` 제거한 점 확인바랍니다.

## 확인 방법 (선택)
![녹음구현](https://github.com/user-attachments/assets/185a76fb-6091-4d10-a882-5d98940b946d)


