### PR TITLE
Feat: 문제 생성 페이지

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -8,6 +8,7 @@ on:
       - main
 env:
   VITE_MOCK_API: ${{ secrets.VITE_MOCK_API }}
+  VITE_API_URL: ${{ secrets.VITE_API_URL }}
 jobs:
   build_and_deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -9,6 +9,7 @@ permissions:
   pull-requests: write
 env:
   VITE_MOCK_API: ${{ secrets.VITE_MOCK_API }}
+  VITE_API_URL: ${{ secrets.VITE_API_URL }}
 jobs:
   build_and_preview:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.24.0",
         "socket.io-client": "^4.7.5",
-        "styled-reset": "^4.5.2"
+        "styled-reset": "^4.5.2",
+        "zustand": "^4.5.4"
       },
       "devDependencies": {
         "@tanstack/react-query-devtools": "^5.50.1",
@@ -1774,13 +1775,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.3",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.3.tgz",
       "integrity": "sha512-hti/R0pS0q1/xx+TsI73XIqk26eBsISZ2R0wUijXIngRK9R/e7Xw/cXVxQK7R5JjW+SV4zGcn5hXjudkN/pLIw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4042,6 +4043,14 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
+      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/vite": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.3.1.tgz",
@@ -4185,6 +4194,33 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.4.tgz",
+      "integrity": "sha512-/BPMyLKJPtFEvVL0E9E9BTUM63MNyhPGlvxk1XjrfWTUlV+BR8jufjsovHzrtR6YNcBEcL7cMHovL1n9xHawEg==",
+      "dependencies": {
+        "use-sync-external-store": "1.2.0"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.24.0",
     "socket.io-client": "^4.7.5",
-    "styled-reset": "^4.5.2"
+    "styled-reset": "^4.5.2",
+    "zustand": "^4.5.4"
   },
   "devDependencies": {
     "@tanstack/react-query-devtools": "^5.50.1",

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,3 +1,3 @@
-const mockAPI_URL: string = import.meta.env.VITE_MOCK_API;
+export const mockAPI_URL: string = import.meta.env.VITE_MOCK_API;
 
-export default mockAPI_URL;
+export const API_URL: string = import.meta.env.VITE_API_URL;

--- a/src/apis/schedule.ts
+++ b/src/apis/schedule.ts
@@ -1,4 +1,4 @@
-import mockAPI_URL from '.';
+import { mockAPI_URL } from '.';
 import { IScheduleElement } from '../constants/schedule';
 
 interface IGetScheduleResponse {

--- a/src/apis/script.ts
+++ b/src/apis/script.ts
@@ -1,0 +1,35 @@
+import { API_URL } from '.';
+
+const token = //임시 token
+  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIwMTZiZDAyOC03OGMxLTRjZTUtYjlhNC1hZDc0Y2ZlYzNkZTIiLCJyb2xlIjoiVVNFUiIsImV4cCI6MTcyMjA3NzAzNX0.dN5G2bMI0jah-peCWY_xn1c-iHRxTW7EjttbKKm86ak';
+
+interface IGetAllScriptResponse {
+  status: string;
+  msg: string;
+  object: IScriptInList[];
+  success: boolean;
+}
+
+export interface IScriptInList {
+  id: string;
+  name: string;
+  processedScript: string[];
+  scheduleElementId: number;
+  lectureDate: string;
+  createdAt: string;
+  problems: null;
+}
+
+export const getScripts = async (): Promise<IScriptInList[]> => {
+  try {
+    const res = await fetch(`${API_URL}/api/v1/lecture/getAllLecture`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data: IGetAllScriptResponse = await res.json();
+    return data.object;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/apis/script.ts
+++ b/src/apis/script.ts
@@ -20,7 +20,7 @@ export interface IScriptInList {
   problems: null;
 }
 
-export const getScripts = async (): Promise<IScriptInList[]> => {
+export const getAllScripts = async (): Promise<IScriptInList[]> => {
   try {
     const res = await fetch(`${API_URL}/api/v1/lecture/getAllLecture`, {
       headers: {

--- a/src/assets/images/check.svg
+++ b/src/assets/images/check.svg
@@ -1,0 +1,3 @@
+<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M1 5L3.69129 7.96042C4.1538 8.46918 4.97989 8.37021 5.30913 7.7666L9 1" stroke="white" stroke-width="2" stroke-linecap="round"/>
+</svg>

--- a/src/components/common/buttons/QuestionTypeBtn/QuestionTypeBtn.module.scss
+++ b/src/components/common/buttons/QuestionTypeBtn/QuestionTypeBtn.module.scss
@@ -1,0 +1,18 @@
+@import '../../../../styles/variables/colors.scss';
+@import '../../../../styles/variables/fonts.scss';
+
+.qtypeBtn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px 16px;
+  background-color: $white_FF;
+  border: 1px solid $light-bg_E5;
+  border-radius: 8px;
+  @include Medium_Body_16;
+  color: $light-gray_81;
+  &.active {
+    color: $dark-orange_E5;
+    border: 1px solid $dark-orange_E5;
+  }
+}

--- a/src/components/common/buttons/QuestionTypeBtn/QuestionTypeBtn.tsx
+++ b/src/components/common/buttons/QuestionTypeBtn/QuestionTypeBtn.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { translateTypeToEnglish } from '../../../../utils/test';
+import styles from './QuestionTypeBtn.module.scss';
+import useQuestionTypeStore from '../../../../store/QuestionTypeStore';
+
+interface IProps {
+  children: string;
+}
+
+const QuestionTypeBtn = ({ children }: IProps) => {
+  const enQuestionType = translateTypeToEnglish(children);
+  const isIncluded = useQuestionTypeStore((state) =>
+    state.questionTypes.includes(enQuestionType),
+  );
+  const { pushQuestionType, popQuestionType } = useQuestionTypeStore();
+  const handleClick = () => {
+    if (isIncluded) {
+      popQuestionType(enQuestionType);
+    } else {
+      pushQuestionType(enQuestionType);
+    }
+  };
+
+  return (
+    <button
+      className={`${styles.qtypeBtn} ${isIncluded && styles.active}`}
+      onClick={handleClick}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default QuestionTypeBtn;

--- a/src/components/common/buttons/QuestionTypeBtn/QuestionTypeBtn.tsx
+++ b/src/components/common/buttons/QuestionTypeBtn/QuestionTypeBtn.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useState } from 'react';
 import { translateTypeToEnglish } from '../../../../utils/test';
 import styles from './QuestionTypeBtn.module.scss';
 import useQuestionTypeStore from '../../../../store/QuestionTypeStore';

--- a/src/components/common/buttons/QuestionTypeBtn/QuestionTypeBtn.tsx
+++ b/src/components/common/buttons/QuestionTypeBtn/QuestionTypeBtn.tsx
@@ -1,6 +1,6 @@
 import { translateTypeToEnglish } from '../../../../utils/test';
 import styles from './QuestionTypeBtn.module.scss';
-import useQuestionTypeStore from '../../../../store/QuestionTypeStore';
+import useQuestionTypeStore from '../../../../store/TestSettingsStore';
 
 interface IProps {
   children: string;

--- a/src/components/common/buttons/StartBtn/StartBtn.module.scss
+++ b/src/components/common/buttons/StartBtn/StartBtn.module.scss
@@ -7,6 +7,6 @@
   cursor: pointer;
   border-width: 0;
   padding: 12px 24px;
-  @include Regular_Body_16;
+  @include SemiBold_Body_16;
   color: $white_FF;
 }

--- a/src/components/headers/RecordHeader/RecordHeader.tsx
+++ b/src/components/headers/RecordHeader/RecordHeader.tsx
@@ -40,9 +40,11 @@ const RecordHeader = ({ handleQuit }: IProps) => {
 
   return (
     <header className={styles.container}>
-      <Link to="/home">
-        <Back />
-      </Link>
+      <span className={styles.linkContainer}>
+        <Link to="/home">
+          <Back />
+        </Link>
+      </span>
       <div className={styles.titleContainer}>
         <h1 className={styles.title}>{RECORD_TITLE}</h1>
         <button className={styles.tagBtn}>태그</button>

--- a/src/components/headers/TestHeader/TestHeader.module.scss
+++ b/src/components/headers/TestHeader/TestHeader.module.scss
@@ -15,39 +15,16 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 .linkContainer {
-  width: 200px;
-}
-.titleContainer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 10px;
+  width: 100px;
 }
 .title {
   @include Medium_Body_18;
   color: $dark-font_5A;
 }
-.tagBtn {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 5px 10px;
-  background-color: white;
-  @include SemiBold_Sub_14;
-  color: $light-gray_81;
-  border: 1px solid $light-bg_E5;
-  border-radius: 8px;
-}
-.timerContainer {
+.quitBtnContainer {
   display: flex;
   justify-content: flex-end;
-  align-items: center;
-  gap: 10px;
-  width: 200px;
-}
-.timer {
-  @include Medium_Sub_14;
-  color: $dark-font_5A;
+  width: 100px;
 }
 .quitBtn {
   display: flex;

--- a/src/components/headers/TestHeader/TestHeader.tsx
+++ b/src/components/headers/TestHeader/TestHeader.tsx
@@ -1,0 +1,23 @@
+import { Link } from 'react-router-dom';
+import styles from './TestHeader.module.scss';
+import Back from '../../../assets/images/arrow/back.svg?react';
+
+const TEST_TITLE = '테스트-경제학원론-240708'; //임시
+
+const TestHeader = () => {
+  return (
+    <header className={styles.container}>
+      <span className={styles.linkContainer}>
+        <Link to="/home">
+          <Back />
+        </Link>
+      </span>
+      <h1 className={styles.title}>{TEST_TITLE}</h1>
+      <span className={styles.quitBtnContainer}>
+        <button className={styles.quitBtn}>종료</button>
+      </span>
+    </header>
+  );
+};
+
+export default TestHeader;

--- a/src/components/headers/TestHeader/TestHeader.tsx
+++ b/src/components/headers/TestHeader/TestHeader.tsx
@@ -8,7 +8,7 @@ const TestHeader = () => {
   return (
     <header className={styles.container}>
       <span className={styles.linkContainer}>
-        <Link to="/home">
+        <Link to="/home/test-make">
           <Back />
         </Link>
       </span>

--- a/src/pages/Main/MyScript/MyScript.module.scss
+++ b/src/pages/Main/MyScript/MyScript.module.scss
@@ -8,7 +8,7 @@
   padding: 30px 40px;
 }
 .headerContainer {
-  @include Medium_Title_24;
+  @include SemiBold_Title_28;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/pages/Main/TestMake/TestMake.module.scss
+++ b/src/pages/Main/TestMake/TestMake.module.scss
@@ -1,0 +1,133 @@
+@import '../../../styles/variables/colors.scss';
+@import '../../../styles/variables/fonts.scss';
+
+.wholeContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  width: 100%;
+  padding: 30px 40px;
+}
+.titleContainer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.title {
+  @include SemiBold_Title_28;
+  color: $dark-font_5A;
+}
+.testStartBtn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 12px 24px;
+  border: none;
+  border-radius: 24px;
+  background-color: $brand-point;
+  color: $white_FF;
+  @include SemiBold_Body_16;
+}
+.contentContainer {
+  display: flex;
+  align-items: flex-start;
+  gap: 20px;
+  flex-grow: 1;
+}
+.scriptsContainer {
+  display: flex;
+  height: 100%;
+  flex-wrap: wrap;
+  flex-grow: 1;
+  background-color: $light-bg_F2;
+  border-radius: 8px;
+}
+.noScript {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  flex-grow: 1;
+  height: 100%;
+  background-color: $light-bg_F2;
+  border-radius: 8px;
+}
+.noScriptText {
+  @include SemiBold_Body_18;
+  color: $light-font_9E;
+}
+.noScriptCaption {
+  @include Medium_Sub_14;
+  color: $light-font_9E;
+}
+.testOptionContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 30px;
+  padding: 30px;
+  background-color: $white_FF;
+  border-radius: 8px;
+}
+.selectBox {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  position: relative;
+}
+.selectTitle {
+  @include SemiBold_Body_16;
+  color: $dark-font_5A;
+}
+.selectionBtnsContainer {
+  display: flex;
+  gap: 10px;
+}
+.qtypeBtn {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 12px 24px;
+  background-color: $white_FF;
+  border: 1px solid $light-bg_E5;
+  border-radius: 8px;
+  @include Medium_Body_16;
+  color: $light-gray_81;
+  &.active {
+    color: $dark-orange_E5;
+    border: 1px solid $dark-orange_E5;
+  }
+}
+.numInput {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 12px 24px 12px 12px;
+  border: 1px solid $light-bg_E5;
+  border-radius: 8px;
+  @include Medium_Body_16;
+  color: $dark-orange_E5;
+}
+.inputCaption {
+  position: absolute;
+  bottom: 14px;
+  right: 14px;
+  @include Medium_Body_16;
+  color: $light-gray_81;
+}
+.checkBoxTitle {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  @include SemiBold_Body_16;
+  color: $dark-font_5A;
+}
+// .timeLimitInput {
+//   display: none;
+// }
+// .timeLimitInput + label:before {
+//     width: 16px;
+//   height: 16px;
+//   border: 1px solid $brand-point;
+//   border-radius: 3px;
+// }

--- a/src/pages/Main/TestMake/TestMake.module.scss
+++ b/src/pages/Main/TestMake/TestMake.module.scss
@@ -102,7 +102,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 12px 24px 12px 12px;
+  padding: 12px 24px 12px calc(50% - 24px);
   border: 1px solid $light-bg_E5;
   border-radius: 8px;
   @include Medium_Body_16;

--- a/src/pages/Main/TestMake/TestMake.module.scss
+++ b/src/pages/Main/TestMake/TestMake.module.scss
@@ -87,7 +87,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 12px 24px;
+  padding: 10px 20px;
   background-color: $white_FF;
   border: 1px solid $light-bg_E5;
   border-radius: 8px;

--- a/src/pages/Main/TestMake/TestMake.module.scss
+++ b/src/pages/Main/TestMake/TestMake.module.scss
@@ -83,21 +83,6 @@
   display: flex;
   gap: 10px;
 }
-.qtypeBtn {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 8px 16px;
-  background-color: $white_FF;
-  border: 1px solid $light-bg_E5;
-  border-radius: 8px;
-  @include Medium_Body_16;
-  color: $light-gray_81;
-  &.active {
-    color: $dark-orange_E5;
-    border: 1px solid $dark-orange_E5;
-  }
-}
 .numInput {
   display: flex;
   justify-content: center;

--- a/src/pages/Main/TestMake/TestMake.module.scss
+++ b/src/pages/Main/TestMake/TestMake.module.scss
@@ -27,6 +27,7 @@
   background-color: $brand-point;
   color: $white_FF;
   @include SemiBold_Body_16;
+  cursor: pointer;
 }
 .contentContainer {
   display: flex;

--- a/src/pages/Main/TestMake/TestMake.module.scss
+++ b/src/pages/Main/TestMake/TestMake.module.scss
@@ -87,7 +87,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 10px 20px;
+  padding: 8px 16px;
   background-color: $white_FF;
   border: 1px solid $light-bg_E5;
   border-radius: 8px;
@@ -122,12 +122,32 @@
   @include SemiBold_Body_16;
   color: $dark-font_5A;
 }
-// .timeLimitInput {
-//   display: none;
-// }
-// .timeLimitInput + label:before {
-//     width: 16px;
-//   height: 16px;
-//   border: 1px solid $brand-point;
-//   border-radius: 3px;
-// }
+.checkBoxContainer {
+  display: flex;
+}
+.timeLimitInput {
+  display: none;
+}
+.timeLimitInput + label {
+  cursor: pointer;
+}
+label:before {
+  margin-right: 3px;
+}
+.timeLimitInput + label:before {
+  content: '';
+  display: flex;
+  width: 16px;
+  height: 16px;
+  border: 1px solid $brand-point;
+  border-radius: 3px;
+}
+.timeLimitInput:checked + label:before {
+  content: '';
+  background-color: $brand-point;
+  border: 1px solid $brand-point;
+  border-radius: 3px;
+  background-image: url('../../../assets/images/check.svg');
+  background-repeat: no-repeat;
+  background-position: 50%;
+}

--- a/src/pages/Main/TestMake/TestMake.tsx
+++ b/src/pages/Main/TestMake/TestMake.tsx
@@ -3,8 +3,11 @@ import styles from './TestMake.module.scss';
 import { getAllScripts, IScriptInList } from '../../../apis/script';
 import QuestionTypeBtn from '../../../components/common/buttons/QuestionTypeBtn/QuestionTypeBtn';
 import useTestSettingsStore from '../../../store/TestSettingsStore';
+import { useNavigate } from 'react-router-dom';
 
 const TestMake = () => {
+  const navigate = useNavigate();
+
   const { data } = useQuery<IScriptInList[], Error>({
     queryKey: ['allScripts'],
     queryFn: () => getAllScripts(),
@@ -30,11 +33,21 @@ const TestMake = () => {
     setTimeLimit(parseInt(e.target.value, 10));
   };
 
+  const handleTestStartBtnClick = () => {
+    // 문제 유형 유효성 검사 로직 구현 예정
+    navigate('/test');
+  };
+
   return (
     <div className={styles.wholeContainer}>
       <div className={styles.titleContainer}>
         <h2 className={styles.title}>문제 스크립트</h2>
-        <button className={styles.testStartBtn}>테스트 시작</button>
+        <button
+          className={styles.testStartBtn}
+          onClick={handleTestStartBtnClick}
+        >
+          테스트 시작
+        </button>
       </div>
       <div className={styles.contentContainer}>
         {data && data.length > 0 ? (

--- a/src/pages/Main/TestMake/TestMake.tsx
+++ b/src/pages/Main/TestMake/TestMake.tsx
@@ -2,12 +2,33 @@ import { useQuery } from '@tanstack/react-query';
 import styles from './TestMake.module.scss';
 import { getAllScripts, IScriptInList } from '../../../apis/script';
 import QuestionTypeBtn from '../../../components/common/buttons/QuestionTypeBtn/QuestionTypeBtn';
+import useTestSettingsStore from '../../../store/TestSettingsStore';
 
 const TestMake = () => {
   const { data } = useQuery<IScriptInList[], Error>({
     queryKey: ['allScripts'],
     queryFn: () => getAllScripts(),
   });
+
+  const { questionCount, timeLimit, setQuestionCount, setTimeLimit } =
+    useTestSettingsStore();
+
+  const handleQuestionCountChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setQuestionCount(parseInt(e.target.value, 10));
+  };
+
+  const handleTimeLimitChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const checked = e.target.checked;
+    setTimeLimit(checked ? 0 : null);
+  };
+
+  const handleTimeLimitValueChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    setTimeLimit(parseInt(e.target.value, 10));
+  };
 
   return (
     <div className={styles.wholeContainer}>
@@ -39,7 +60,13 @@ const TestMake = () => {
           </div>
           <div className={styles.selectBox}>
             <p className={styles.selectTitle}>문제 개수</p>
-            <input className={styles.numInput} type="number" min="0" />
+            <input
+              className={styles.numInput}
+              type="number"
+              min="0"
+              value={questionCount}
+              onChange={handleQuestionCountChange}
+            />
             <span className={styles.inputCaption}>개</span>
           </div>
           <div className={styles.selectBox}>
@@ -48,13 +75,25 @@ const TestMake = () => {
                 className={styles.timeLimitInput}
                 type="checkbox"
                 id="time"
+                checked={timeLimit !== null}
+                onChange={handleTimeLimitChange}
               />
               <label className={styles.checkBoxTitle} htmlFor="time">
                 시간 제한
               </label>
             </span>
-            <input className={styles.numInput} type="number" min="0" />
-            <span className={styles.inputCaption}>분</span>
+            {timeLimit !== null && (
+              <>
+                <input
+                  className={styles.numInput}
+                  type="number"
+                  min="0"
+                  value={timeLimit}
+                  onChange={handleTimeLimitValueChange}
+                />
+                <span className={styles.inputCaption}>분</span>
+              </>
+            )}
           </div>
         </section>
       </div>

--- a/src/pages/Main/TestMake/TestMake.tsx
+++ b/src/pages/Main/TestMake/TestMake.tsx
@@ -41,10 +41,16 @@ const TestMake = () => {
             <span className={styles.inputCaption}>개</span>
           </div>
           <div className={styles.selectBox}>
-            <label className={styles.checkBoxTitle}>
-              <input className={styles.timeLimitInput} type="checkbox" />
-              시간 제한
-            </label>
+            <span className={styles.checkBoxContainer}>
+              <input
+                className={styles.timeLimitInput}
+                type="checkbox"
+                id="time"
+              />
+              <label className={styles.checkBoxTitle} htmlFor="time">
+                시간 제한
+              </label>
+            </span>
             <input className={styles.numInput} type="number" />
             <span className={styles.inputCaption}>분</span>
           </div>

--- a/src/pages/Main/TestMake/TestMake.tsx
+++ b/src/pages/Main/TestMake/TestMake.tsx
@@ -30,10 +30,11 @@ const TestMake = () => {
           <div className={styles.selectBox}>
             <p className={styles.selectTitle}>문제 유형</p>
             <div className={styles.selectionBtnsContainer}>
-              <QuestionTypeBtn>객관식</QuestionTypeBtn>
-              <QuestionTypeBtn>단답형</QuestionTypeBtn>
-              <QuestionTypeBtn>빈칸 뚫기</QuestionTypeBtn>
-              <QuestionTypeBtn>OX 퀴즈</QuestionTypeBtn>
+              {['객관식', '단답형', '빈칸 뚫기', 'OX 퀴즈'].map(
+                (type, index) => (
+                  <QuestionTypeBtn key={index}>{type}</QuestionTypeBtn>
+                ),
+              )}
             </div>
           </div>
           <div className={styles.selectBox}>

--- a/src/pages/Main/TestMake/TestMake.tsx
+++ b/src/pages/Main/TestMake/TestMake.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import styles from './TestMake.module.scss';
 import { getAllScripts, IScriptInList } from '../../../apis/script';
+import QuestionTypeBtn from '../../../components/common/buttons/QuestionTypeBtn/QuestionTypeBtn';
 
 const TestMake = () => {
   const { data } = useQuery<IScriptInList[], Error>({
@@ -29,15 +30,15 @@ const TestMake = () => {
           <div className={styles.selectBox}>
             <p className={styles.selectTitle}>문제 유형</p>
             <div className={styles.selectionBtnsContainer}>
-              <button className={styles.qtypeBtn}>객관식</button>
-              <button className={styles.qtypeBtn}>단답형</button>
-              <button className={styles.qtypeBtn}>빈칸 뚫기</button>
-              <button className={styles.qtypeBtn}>OX 퀴즈</button>
+              <QuestionTypeBtn>객관식</QuestionTypeBtn>
+              <QuestionTypeBtn>단답형</QuestionTypeBtn>
+              <QuestionTypeBtn>빈칸 뚫기</QuestionTypeBtn>
+              <QuestionTypeBtn>OX 퀴즈</QuestionTypeBtn>
             </div>
           </div>
           <div className={styles.selectBox}>
             <p className={styles.selectTitle}>문제 개수</p>
-            <input className={styles.numInput} type="number" />
+            <input className={styles.numInput} type="number" min="0" />
             <span className={styles.inputCaption}>개</span>
           </div>
           <div className={styles.selectBox}>
@@ -51,7 +52,7 @@ const TestMake = () => {
                 시간 제한
               </label>
             </span>
-            <input className={styles.numInput} type="number" />
+            <input className={styles.numInput} type="number" min="0" />
             <span className={styles.inputCaption}>분</span>
           </div>
         </section>

--- a/src/pages/Main/TestMake/TestMake.tsx
+++ b/src/pages/Main/TestMake/TestMake.tsx
@@ -1,5 +1,57 @@
+import { useQuery } from '@tanstack/react-query';
+import styles from './TestMake.module.scss';
+import { getAllScripts, IScriptInList } from '../../../apis/script';
+
 const TestMake = () => {
-  return <div>TestMake</div>;
+  const { data } = useQuery<IScriptInList[], Error>({
+    queryKey: ['allScripts'],
+    queryFn: () => getAllScripts(),
+  });
+
+  return (
+    <div className={styles.wholeContainer}>
+      <div className={styles.titleContainer}>
+        <h2 className={styles.title}>문제 스크립트</h2>
+        <button className={styles.testStartBtn}>테스트 시작</button>
+      </div>
+      <div className={styles.contentContainer}>
+        {data && data.length > 0 ? (
+          <section className={styles.scriptsContainer}></section>
+        ) : (
+          <section className={styles.noScript}>
+            <p className={styles.noScriptText}>스크립트 없음</p>
+            <p className={styles.noScriptCaption}>
+              녹음 시작 버튼을 눌러 만들어보세요
+            </p>
+          </section>
+        )}
+        <section className={styles.testOptionContainer}>
+          <div className={styles.selectBox}>
+            <p className={styles.selectTitle}>문제 유형</p>
+            <div className={styles.selectionBtnsContainer}>
+              <button className={styles.qtypeBtn}>객관식</button>
+              <button className={styles.qtypeBtn}>단답형</button>
+              <button className={styles.qtypeBtn}>빈칸 뚫기</button>
+              <button className={styles.qtypeBtn}>OX 퀴즈</button>
+            </div>
+          </div>
+          <div className={styles.selectBox}>
+            <p className={styles.selectTitle}>문제 개수</p>
+            <input className={styles.numInput} type="number" />
+            <span className={styles.inputCaption}>개</span>
+          </div>
+          <div className={styles.selectBox}>
+            <label className={styles.checkBoxTitle}>
+              <input className={styles.timeLimitInput} type="checkbox" />
+              시간 제한
+            </label>
+            <input className={styles.numInput} type="number" />
+            <span className={styles.inputCaption}>분</span>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
 };
 
 export default TestMake;

--- a/src/pages/Test/Test.module.scss
+++ b/src/pages/Test/Test.module.scss
@@ -1,0 +1,20 @@
+@import '../../styles/variables/colors.scss';
+@import '../../styles/variables/fonts.scss';
+
+.container {
+  display: flex;
+  justify-content: center;
+  width: 100dvw;
+  min-height: 100dvh;
+  background-color: $light-bg_F2;
+}
+.problemsContainer {
+  display: flex;
+  width: 60%;
+  padding: 50px;
+  margin-top: 100px;
+  background-color: white;
+  border: none;
+  border-top-left-radius: 12px;
+  border-top-right-radius: 12px;
+}

--- a/src/pages/Test/Test.tsx
+++ b/src/pages/Test/Test.tsx
@@ -1,0 +1,13 @@
+import TestHeader from '../../components/headers/TestHeader/TestHeader';
+import styles from './Test.module.scss';
+
+const Test = () => {
+  return (
+    <div className={styles.container}>
+      <TestHeader />
+      <article className={styles.problemsContainer}></article>
+    </div>
+  );
+};
+
+export default Test;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -9,6 +9,7 @@ import MyScript from './Main/MyScript/MyScript';
 import TrashCan from './Main/TrashCan/TrashCan';
 import PrivateRoute from './PrivateRoute';
 import Record from './Record/Record';
+import Test from './Test/Test';
 
 const router = createBrowserRouter([
   {
@@ -50,6 +51,10 @@ const router = createBrowserRouter([
   {
     path: '/record',
     element: <PrivateRoute element={<Record />} />,
+  },
+  {
+    path: '/test',
+    element: <PrivateRoute element={<Test />} />,
   },
 ]);
 

--- a/src/store/QuestionTypeStore.ts
+++ b/src/store/QuestionTypeStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand';
+import { EnQuestionType } from '../utils/test';
+
+type QuestionTypeStore = {
+  questionTypes: EnQuestionType[];
+  pushQuestionType: (type: EnQuestionType) => void;
+  popQuestionType: (type: EnQuestionType) => void;
+  clearQuestionType: () => void;
+};
+
+const useQuestionTypeStore = create<QuestionTypeStore>()((set) => ({
+  questionTypes: ['MultipleChoice'],
+
+  pushQuestionType: (type) =>
+    set((state) => ({
+      questionTypes: state.questionTypes.includes(type)
+        ? state.questionTypes
+        : [...state.questionTypes, type],
+    })),
+
+  popQuestionType: (type: EnQuestionType) =>
+    set((state) => ({
+      questionTypes: state.questionTypes.filter((t) => t !== type),
+    })),
+
+  clearQuestionType: () => set({ questionTypes: [] }),
+}));
+
+export default useQuestionTypeStore;

--- a/src/store/TestSettingsStore.ts
+++ b/src/store/TestSettingsStore.ts
@@ -1,15 +1,21 @@
 import { create } from 'zustand';
 import { EnQuestionType } from '../utils/test';
 
-type QuestionTypeStore = {
+type TestSettingsStore = {
   questionTypes: EnQuestionType[];
+  questionCount: number;
+  timeLimit: number | null;
   pushQuestionType: (type: EnQuestionType) => void;
   popQuestionType: (type: EnQuestionType) => void;
-  clearQuestionType: () => void;
+  setQuestionCount: (count: number) => void;
+  setTimeLimit: (limit: number | null) => void;
+  clearSettings: () => void;
 };
 
-const useQuestionTypeStore = create<QuestionTypeStore>()((set) => ({
+const useTestSettingsStore = create<TestSettingsStore>()((set) => ({
   questionTypes: ['MultipleChoice'],
+  questionCount: 0,
+  timeLimit: null,
 
   pushQuestionType: (type) =>
     set((state) => ({
@@ -23,7 +29,12 @@ const useQuestionTypeStore = create<QuestionTypeStore>()((set) => ({
       questionTypes: state.questionTypes.filter((t) => t !== type),
     })),
 
-  clearQuestionType: () => set({ questionTypes: [] }),
+  setQuestionCount: (count: number) => set({ questionCount: count }),
+
+  setTimeLimit: (limit: number | null) => set({ timeLimit: limit }),
+
+  clearSettings: () =>
+    set({ questionTypes: [], questionCount: 0, timeLimit: null }),
 }));
 
-export default useQuestionTypeStore;
+export default useTestSettingsStore;

--- a/src/styles/variables/fonts.scss
+++ b/src/styles/variables/fonts.scss
@@ -1,6 +1,6 @@
 @mixin SemiBold_Title_28 {
   font-family: 'Pretendard-SemiBold';
-  font-size: 32pt;
+  font-size: 28pt;
   letter-spacing: -0.025em;
 }
 

--- a/src/styles/variables/fonts.scss
+++ b/src/styles/variables/fonts.scss
@@ -1,80 +1,80 @@
 @mixin SemiBold_Title_28 {
   font-family: 'Pretendard-SemiBold';
-  font-size: 28pt;
+  font-size: 28px;
   letter-spacing: -0.025em;
 }
 
 @mixin Medium_Title_24 {
   // 임의로 추가
   font-family: 'Pretendard-Medium';
-  font-size: 24pt;
+  font-size: 24px;
   letter-spacing: -0.025em;
 }
 
 @mixin SemiBold_Body_18 {
   font-family: 'Pretendard-SemiBold';
-  font-size: 18pt;
+  font-size: 18px;
   letter-spacing: -0.025em;
 }
 
 @mixin Medium_Body_18 {
   font-family: 'Pretendard-Medium';
-  font-size: 18pt;
+  font-size: 18px;
   letter-spacing: -0.025em;
 }
 
 @mixin Regular_Body_18 {
   font-family: 'Pretendard-Regular';
-  font-size: 18pt;
+  font-size: 18px;
   letter-spacing: -0.025em;
 }
 
 @mixin Regular_Body_18_200 {
   font-family: 'Pretendard-Regular';
-  font-size: 18pt;
+  font-size: 18px;
   letter-spacing: -0.025em;
   line-height: 200%;
 }
 
 @mixin SemiBold_Body_16 {
   font-family: 'Pretendard-SemiBold';
-  font-size: 16pt;
+  font-size: 16px;
   letter-spacing: -0.025em;
 }
 
 @mixin Medium_Body_16 {
   font-family: 'Pretendard-Medium';
-  font-size: 16pt;
+  font-size: 16px;
   letter-spacing: -0.025em;
 }
 
 @mixin Regular_Body_16 {
   font-family: 'Pretendard-Regular';
-  font-size: 16pt;
+  font-size: 16px;
   letter-spacing: -0.025em;
 }
 
 @mixin SemiBold_Sub_14 {
   font-family: 'Pretendard-SemiBold';
-  font-size: 14pt;
+  font-size: 14px;
   letter-spacing: -0.025em;
 }
 
 @mixin Medium_Sub_14 {
   font-family: 'Pretendard-Medium';
-  font-size: 14pt;
+  font-size: 14px;
   letter-spacing: -0.025em;
 }
 
 @mixin Regular_Sub_14 {
   font-family: 'Pretendard-Regular';
-  font-size: 14pt;
+  font-size: 14px;
   letter-spacing: -0.025em;
 }
 
 @mixin Regular_Sub_14_150 {
   font-family: 'Pretendard-Regular';
-  font-size: 14pt;
+  font-size: 14px;
   letter-spacing: -0.025em;
   line-height: 150%;
 }

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -1,0 +1,13 @@
+export type EnQuestionType =
+  | 'MultipleChoice'
+  | 'ShrotAnswer'
+  | 'BlanckQuestion'
+  | 'OXChoice';
+
+export const translateTypeToEnglish = (type: string): EnQuestionType => {
+  if (type === '객관식') return 'MultipleChoice';
+  if (type === '단답형') return 'ShrotAnswer';
+  if (type === '빈칸 뚫기') return 'BlanckQuestion';
+  if (type === 'OX 퀴즈') return 'OXChoice';
+  return 'MultipleChoice';
+};


### PR DESCRIPTION
## 요약 (Summary)

문제 생성 페이지 레이아웃 작성 및 문제 설정 store 생성

## 변경 사항 (Changes)

- 실제 Spring 서버 URL 환경변수 추가
- 문제 생성 페이지 레이아웃 작성
- 문제 페이지 라우터 추가 및 전체 레이아웃 작성
- 디자인 시스템 폰트 pt -> px로 변경
- 문제 설정 store 작성 : `TestSettingsStore.ts -> useTestSettingsStore`

## 리뷰 요구사항

- `.env`에 실제 서버 URL 추가 바랍니다! 
- 문제 생성 페이지에서 스크립트 선택하는 부분은 CORS 허용이 아직 안되어서 데이터가 안불러와지므로 나중에 구현하겠습니다! (mock 서버로 연결해서 할 수도 있지만 업무를 조금 미루겠습니다..ㅎㅎ)
- 시간 제한 부분은 초기에 분을 입력하는 input이 안보이다가 체크 상태가 true 일 때만 input이 보이도록 설정했습니다.

## 확인 방법 (선택)
![image](https://github.com/user-attachments/assets/a734ca3b-7f4d-47a1-990f-4453ffc67955)


![image](https://github.com/user-attachments/assets/3efe123d-0b4a-4741-9bd9-a21f77842a0c)

