### PR TITLE
Fix: 시간표 API mock 서버 연결 해제 및 실제 서버 연결

### DIFF
--- a/src/apis/schedule.ts
+++ b/src/apis/schedule.ts
@@ -1,4 +1,4 @@
-import { mockAPI_URL } from '.';
+import { API_URL } from '.';
 import { IScheduleElement } from '../constants/schedule';
 
 interface IGetScheduleResponse {
@@ -17,7 +17,7 @@ export const getSchedule = async (
   name: string,
 ): Promise<IScheduleElement[]> => {
   try {
-    const res = await fetch(`${mockAPI_URL}/schedule/getSchedule?name=${name}`);
+    const res = await fetch(`${API_URL}/schedule/getSchedule?name=${name}`);
     const data: IGetScheduleResponse = await res.json();
     return data.object['scheduleElements'];
   } catch (error) {


### PR DESCRIPTION
## 요약 (Summary)

시간표 API mock 서버 연결 해제 및 실제 서버 연결

## 변경 사항 (Changes)

시간표 API mock 서버에 연결되어있던 것 실제 서버로 연결

## 리뷰 요구사항

- mock 서버가 제한 요청량을 초과하여 더이상 안되어서 실제서버로 바꿨습니다.
- 근데 실제 서버에는 `name`에 `건국대학교 3-1학기`를 넣으면 404로 응답이 옵니다. @judemin 
  - 임시로 `건국대학교 3-1학기`를 넣고 있었는데 이 부분을 어떻게 해야할지도 정해야 할 것 같습니다.

## 확인 방법 (선택)

![image](https://github.com/user-attachments/assets/15d95d10-0b8b-4274-bdbc-c7940db540b8)
