### PR TITLE
Feat: 시간표별 스크립트 목록 툴팁

### DIFF
--- a/src/apis/schedule.ts
+++ b/src/apis/schedule.ts
@@ -32,3 +32,37 @@ export const getSchedule = async (
     throw error;
   }
 };
+
+interface IGetLectureByScheduleElementResponse {
+  status: string;
+  msg: string;
+  object: ILectureItem[];
+  success: boolean;
+}
+
+interface ILectureItem {
+  id: string;
+  name: string;
+  processedScript: null;
+  scheduleElementId: string;
+  lectureDate: string;
+  createdAt: string;
+  problems: null;
+}
+
+export const getLectureByScheduleElement = async (id: number) => {
+  try {
+    const res = await fetch(
+      `${API_URL}/api/v1/lecture/getLectureByScheduleElement?scheduleElementId=${id}`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+    const data: IGetLectureByScheduleElementResponse = await res.json();
+    return data.object;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/components/common/ScriptItem/ScriptItem.tsx
+++ b/src/components/common/ScriptItem/ScriptItem.tsx
@@ -5,14 +5,14 @@ interface IScriptProps {
   id: string;
   name: string;
   processedScript: string[];
-  createdAt: string;
+  lectureDate: string;
 }
-const ScriptItem = ({ name, processedScript, createdAt }: IScriptProps) => {
+const ScriptItem = ({ name, processedScript, lectureDate }: IScriptProps) => {
   return (
     <div className={styles.postItContainer}>
       <div className={styles.title}>{name}</div>
       <div className={styles.content}>{processedScript[0]}...</div>
-      <span className={styles.date}>{formatScriptDate(createdAt)}</span>
+      <span className={styles.date}>{formatScriptDate(lectureDate)}</span>
     </div>
   );
 };

--- a/src/components/common/ScriptToolTip/ScriptToolTip.module.scss
+++ b/src/components/common/ScriptToolTip/ScriptToolTip.module.scss
@@ -21,4 +21,5 @@
   @include Medium_Body_16;
   color: $dark-font_33;
   border-bottom: 1px solid $light-bg_F2;
+  cursor: pointer;
 }

--- a/src/components/common/ScriptToolTip/ScriptToolTip.module.scss
+++ b/src/components/common/ScriptToolTip/ScriptToolTip.module.scss
@@ -1,0 +1,24 @@
+@import '../../../styles/variables/colors.scss';
+@import '../../../styles/variables/fonts.scss';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  padding: 3px 12px;
+  background-color: $white_FF;
+  border-radius: 8px;
+  box-shadow: 0px 2px 20px 0px rgba(0, 0, 0, 0.1);
+  :last-child {
+    border: none;
+  }
+}
+.tooltipItem {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+  padding: 12px;
+  @include Medium_Body_16;
+  color: $dark-font_33;
+  border-bottom: 1px solid $light-bg_F2;
+}

--- a/src/components/common/ScriptToolTip/ScriptToolTip.tsx
+++ b/src/components/common/ScriptToolTip/ScriptToolTip.tsx
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { getLectureByScheduleElement } from '../../../apis/schedule';
+import ScriptIcon from '../../../assets/images/nav/my-script-inactive.svg?react';
+import styles from './ScriptToolTip.module.scss';
+
+interface IProps {
+  id: number;
+}
+
+const ScriptToolTip = ({ id }: IProps) => {
+  const { data } = useQuery({
+    queryKey: ['tooltip', id],
+    queryFn: () => getLectureByScheduleElement(id),
+  });
+
+  return (
+    <div className={styles.container}>
+      {data?.map((lecture) => (
+        <div className={styles.tooltipItem}>
+          {lecture.name}
+          <ScriptIcon />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ScriptToolTip;

--- a/src/components/common/ScriptToolTip/ScriptToolTip.tsx
+++ b/src/components/common/ScriptToolTip/ScriptToolTip.tsx
@@ -2,25 +2,58 @@ import { useQuery } from '@tanstack/react-query';
 import { getLectureByScheduleElement } from '../../../apis/schedule';
 import ScriptIcon from '../../../assets/images/nav/my-script-inactive.svg?react';
 import styles from './ScriptToolTip.module.scss';
+import ScriptDetailModal from '../../modals/ScriptDetailModal/ScriptDetailModal';
+import { useEffect, useState } from 'react';
 
 interface IProps {
   id: number;
 }
 
 const ScriptToolTip = ({ id }: IProps) => {
+  const [selectedScriptId, setSelectedScriptId] = useState<string | null>(null);
+
   const { data } = useQuery({
     queryKey: ['tooltip', id],
     queryFn: () => getLectureByScheduleElement(id),
   });
 
+  const handleClick = (scriptId: string) => {
+    setSelectedScriptId(scriptId);
+  };
+
+  const handleCloseModal = () => {
+    setSelectedScriptId(null);
+  };
+
+  useEffect(() => {
+    if (selectedScriptId !== null) {
+      document.body.style.overflow = 'hidden';
+    } else {
+      document.body.style.overflow = 'auto';
+    }
+
+    return () => {
+      document.body.style.overflow = 'auto';
+    };
+  }, [selectedScriptId]);
+
   return (
     <div className={styles.container}>
       {data?.map((lecture) => (
-        <div className={styles.tooltipItem}>
+        <div
+          className={styles.tooltipItem}
+          onClick={() => handleClick(lecture.id)}
+        >
           {lecture.name}
           <ScriptIcon />
         </div>
       ))}
+      {selectedScriptId !== null && (
+        <ScriptDetailModal
+          scriptId={selectedScriptId}
+          closeModal={handleCloseModal}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/common/ScriptToolTip/ScriptToolTip.tsx
+++ b/src/components/common/ScriptToolTip/ScriptToolTip.tsx
@@ -17,7 +17,7 @@ const ScriptToolTip = ({ id }: IProps) => {
     queryFn: () => getLectureByScheduleElement(id),
   });
 
-  const handleClick = (scriptId: string) => {
+  const handleToolTipClick = (scriptId: string) => {
     setSelectedScriptId(scriptId);
   };
 
@@ -42,7 +42,7 @@ const ScriptToolTip = ({ id }: IProps) => {
       {data?.map((lecture) => (
         <div
           className={styles.tooltipItem}
-          onClick={() => handleClick(lecture.id)}
+          onClick={() => handleToolTipClick(lecture.id)}
         >
           {lecture.name}
           <ScriptIcon />

--- a/src/components/common/ScriptToolTip/ScriptToolTip.tsx
+++ b/src/components/common/ScriptToolTip/ScriptToolTip.tsx
@@ -1,9 +1,9 @@
+import { useEffect, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
+import ScriptDetailModal from '../../modals/ScriptDetailModal/ScriptDetailModal';
 import { getLectureByScheduleElement } from '../../../apis/schedule';
 import ScriptIcon from '../../../assets/images/nav/my-script-inactive.svg?react';
 import styles from './ScriptToolTip.module.scss';
-import ScriptDetailModal from '../../modals/ScriptDetailModal/ScriptDetailModal';
-import { useEffect, useState } from 'react';
 
 interface IProps {
   id: number;

--- a/src/components/common/TimeTableItem/TimeTableItem.module.scss
+++ b/src/components/common/TimeTableItem/TimeTableItem.module.scss
@@ -34,3 +34,7 @@
   @include Medium_Sub_14;
   word-wrap: break-word;
 }
+
+.tooptipWrapper {
+  position: absolute;
+}

--- a/src/components/common/TimeTableItem/TimeTableItem.module.scss
+++ b/src/components/common/TimeTableItem/TimeTableItem.module.scss
@@ -37,4 +37,6 @@
 
 .tooptipWrapper {
   position: absolute;
+  left: var(--schedule-left);
+  top: var(--schedule-top);
 }

--- a/src/components/common/TimeTableItem/TimeTableItem.module.scss
+++ b/src/components/common/TimeTableItem/TimeTableItem.module.scss
@@ -35,7 +35,7 @@
   word-wrap: break-word;
 }
 
-.tooptipWrapper {
+.tooltipWrapper {
   position: absolute;
   left: var(--schedule-left);
   top: var(--schedule-top);

--- a/src/components/common/TimeTableItem/TimeTableItem.tsx
+++ b/src/components/common/TimeTableItem/TimeTableItem.tsx
@@ -15,11 +15,7 @@ const TimeTableItem = ({
   startTime,
   endTime,
 }: IScheduleElement) => {
-  const { height, top, left, ...style } = getScheduleStyle(
-    dayOfWeek,
-    startTime,
-    endTime,
-  );
+  const { height, ...style } = getScheduleStyle(dayOfWeek, startTime, endTime);
   const { backgroundColor, textColor } = getScheduleItemColor(color);
   const [isShowingToolTip, setIsShowingToolTip] = useState(false);
 
@@ -62,7 +58,7 @@ const TimeTableItem = ({
       {isShowingToolTip && (
         <span
           className={styles.tooptipWrapper}
-          style={{ top: `${top}px`, left }}
+          style={{ ...style }}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >

--- a/src/components/common/TimeTableItem/TimeTableItem.tsx
+++ b/src/components/common/TimeTableItem/TimeTableItem.tsx
@@ -21,15 +21,23 @@ const TimeTableItem = ({
     endTime,
   );
   const { backgroundColor, textColor } = getScheduleItemColor(color);
-  const [showToolTip, setShowToolTip] = useState(false);
+  const [isShowingToolTip, setIsShowingToolTip] = useState(false);
+
+  const handleMouseEnter = () => {
+    setIsShowingToolTip(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsShowingToolTip(false);
+  };
 
   return (
     <>
       <div
         className={styles.scheduleItem}
         style={{ ...style, backgroundColor, color: textColor }}
-        onMouseEnter={() => setShowToolTip(true)}
-        onMouseLeave={() => setShowToolTip(false)}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
       >
         <span className={styles.title}>
           {Number(height) < 33 ? (
@@ -51,12 +59,12 @@ const TimeTableItem = ({
           >{`${startTime.slice(11, 16)}~${endTime.slice(11, 16)}`}</p>
         )}
       </div>
-      {showToolTip && (
+      {isShowingToolTip && (
         <span
           className={styles.tooptipWrapper}
           style={{ top: `${top}px`, left }}
-          onMouseEnter={() => setShowToolTip(true)}
-          onMouseLeave={() => setShowToolTip(false)}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
         >
           <ScriptToolTip id={id} />
         </span>

--- a/src/components/common/TimeTableItem/TimeTableItem.tsx
+++ b/src/components/common/TimeTableItem/TimeTableItem.tsx
@@ -57,7 +57,7 @@ const TimeTableItem = ({
       </div>
       {isShowingToolTip && (
         <span
-          className={styles.tooptipWrapper}
+          className={styles.tooltipWrapper}
           style={{ ...style }}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}

--- a/src/components/common/TimeTableItem/TimeTableItem.tsx
+++ b/src/components/common/TimeTableItem/TimeTableItem.tsx
@@ -2,9 +2,11 @@ import { IScheduleElement } from '../../../constants/schedule';
 import { getScheduleStyle } from '../../../utils/schedule';
 import styles from './TimeTableItem.module.scss';
 import { getScheduleItemColor } from '../../../utils/randomColor';
+import { useState } from 'react';
+import ScriptToolTip from '../ScriptToolTip/ScriptToolTip';
 
 const TimeTableItem = ({
-  //id,
+  id,
   //scheduleId,
   name,
   location,
@@ -13,34 +15,53 @@ const TimeTableItem = ({
   startTime,
   endTime,
 }: IScheduleElement) => {
-  const { height, ...style } = getScheduleStyle(dayOfWeek, startTime, endTime);
+  const { height, top, left, ...style } = getScheduleStyle(
+    dayOfWeek,
+    startTime,
+    endTime,
+  );
   const { backgroundColor, textColor } = getScheduleItemColor(color);
+  const [showToolTip, setShowToolTip] = useState(false);
 
   return (
-    <div
-      className={styles.scheduleItem}
-      style={{ ...style, backgroundColor, color: textColor }}
-    >
-      <span className={styles.title}>
-        {Number(height) < 33 ? (
-          ''
-        ) : 33 < Number(height) && 53 > Number(height) ? (
-          <h6 className={styles.name}>{name}</h6>
-        ) : (
-          <>
+    <>
+      <div
+        className={styles.scheduleItem}
+        style={{ ...style, backgroundColor, color: textColor }}
+        onMouseEnter={() => setShowToolTip(true)}
+        onMouseLeave={() => setShowToolTip(false)}
+      >
+        <span className={styles.title}>
+          {Number(height) < 33 ? (
+            ''
+          ) : 33 < Number(height) && 53 > Number(height) ? (
             <h6 className={styles.name}>{name}</h6>
-            <p className={styles.location}>{location}</p>
-          </>
+          ) : (
+            <>
+              <h6 className={styles.name}>{name}</h6>
+              <p className={styles.location}>{location}</p>
+            </>
+          )}
+        </span>
+        {Number(height) < 73 ? (
+          ''
+        ) : (
+          <p
+            className={styles.time}
+          >{`${startTime.slice(11, 16)}~${endTime.slice(11, 16)}`}</p>
         )}
-      </span>
-      {Number(height) < 73 ? (
-        ''
-      ) : (
-        <p
-          className={styles.time}
-        >{`${startTime.slice(11, 16)}~${endTime.slice(11, 16)}`}</p>
+      </div>
+      {showToolTip && (
+        <span
+          className={styles.tooptipWrapper}
+          style={{ top: `${top}px`, left }}
+          onMouseEnter={() => setShowToolTip(true)}
+          onMouseLeave={() => setShowToolTip(false)}
+        >
+          <ScriptToolTip id={id} />
+        </span>
       )}
-    </div>
+    </>
   );
 };
 

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -29,7 +29,5 @@ export const getScheduleStyle = (
     '--schedule-top': `${top}px`,
     '--schedule-height': `${height + 1}px`,
     height,
-    top,
-    left,
   } as React.CSSProperties;
 };

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -29,5 +29,7 @@ export const getScheduleStyle = (
     '--schedule-top': `${top}px`,
     '--schedule-height': `${height + 1}px`,
     height,
+    top,
+    left,
   } as React.CSSProperties;
 };


### PR DESCRIPTION
## 요약 (Summary)

시간표별 스크립트 목록 툴팁 및 툴팁 클릭시 상세 모달 이벤트

## 변경 사항 (Changes)

- 시간표에 마우스 올릴 시 스크립트 목록 툴팁 
- 툴팁의 스크립트 클릭 시 상세 스크립트 모달
- ScriptItem의 날짜 표시 부분 createdAt -> lectureDate로 수정

## 리뷰 요구사항

## 확인 방법 (선택)

![툴팁](https://github.com/user-attachments/assets/e17caa0e-c96e-46d9-84db-1a281fbe4895)

