### PR TITLE
Feat: 시간표 추가/삭제 API 연결

### DIFF
--- a/src/apis/schedule.ts
+++ b/src/apis/schedule.ts
@@ -1,5 +1,6 @@
 import { API_URL } from '.';
 import { IScheduleElement } from '../constants/schedule';
+import { IScheduleElementDTO } from '../utils/schedule';
 import { getToken } from './';
 
 interface IGetScheduleResponse {
@@ -69,17 +70,40 @@ export const getLectureByScheduleElement = async (id: number) => {
   }
 };
 
-interface IDeleteScheduleElementResponse {
+interface IPOSTScheduleElementResponse {
   status: string;
   msg: string;
   object: null;
   success: boolean;
 }
 
+export const addScheduleElement = async (inputData: IScheduleElementDTO) => {
+  const token = getToken();
+  try {
+    const res = await fetch(`${API_URL}/api/v1/schedule/addElement`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        scheduleDTO: {
+          name: '김히얼', // 동적 할당 구현 예정
+        },
+        scheduleElementDTO: inputData,
+      }),
+    });
+    const data: IPOSTScheduleElementResponse = await res.json();
+    return data.success;
+  } catch (error) {
+    throw new Error('Failed to delete schedule element');
+  }
+};
+
 export const deleteScheduleElement = async (scheduleElementId: number) => {
   const token = getToken();
   try {
-    const res = await fetch(`/api/v1/schedule/deleteElement`, {
+    const res = await fetch(`${API_URL}/api/v1/schedule/deleteElement`, {
       method: 'DELETE',
       headers: {
         'Content-Type': 'application/json',
@@ -94,7 +118,7 @@ export const deleteScheduleElement = async (scheduleElementId: number) => {
         },
       }),
     });
-    const data: IDeleteScheduleElementResponse = await res.json();
+    const data: IPOSTScheduleElementResponse = await res.json();
     return data.success;
   } catch (error) {
     throw new Error('Failed to delete schedule element');

--- a/src/apis/schedule.ts
+++ b/src/apis/schedule.ts
@@ -68,3 +68,35 @@ export const getLectureByScheduleElement = async (id: number) => {
     throw error;
   }
 };
+
+interface IDeleteScheduleElementResponse {
+  status: string;
+  msg: string;
+  object: null;
+  success: boolean;
+}
+
+export const deleteScheduleElement = async (scheduleElementId: number) => {
+  const token = getToken();
+  try {
+    const res = await fetch(`/api/v1/schedule/deleteElement`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({
+        scheduleDTO: {
+          name: '김히얼', // 동적 할당 구현 예정
+        },
+        scheduleElementDTO: {
+          id: scheduleElementId,
+        },
+      }),
+    });
+    const data: IDeleteScheduleElementResponse = await res.json();
+    return data.success;
+  } catch (error) {
+    throw new Error('Failed to delete schedule element');
+  }
+};

--- a/src/assets/images/orange-trash-can.svg
+++ b/src/assets/images/orange-trash-can.svg
@@ -1,0 +1,7 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M3 6H13V13C13 14.1046 12.1046 15 11 15H5C3.89543 15 3 14.1046 3 13V6Z" fill="#FF603D"/>
+<path d="M3 5H13" stroke="#FF603D" stroke-width="2" stroke-linecap="round"/>
+<path d="M5 2H11" stroke="#FF603D" stroke-width="2" stroke-linecap="round"/>
+<rect x="6" y="7" width="1" height="5" rx="0.5" fill="white"/>
+<rect x="9" y="7" width="1" height="5" rx="0.5" fill="white"/>
+</svg>

--- a/src/components/atoms/buttons/TabLink/TabLink.tsx
+++ b/src/components/atoms/buttons/TabLink/TabLink.tsx
@@ -23,7 +23,7 @@ const TabLink = ({
   return (
     <Link to={to} className={`${styles.navItem} ${isActive && styles.active}`}>
       {isActive ? activeIcon : inactiveIcon}
-      <span>{children}</span>
+      <p>{children}</p>
     </Link>
   );
 };

--- a/src/components/molecules/RecordTagDropDown/RecordTagDropDown.tsx
+++ b/src/components/molecules/RecordTagDropDown/RecordTagDropDown.tsx
@@ -5,7 +5,7 @@ import { IScheduleElement } from '../../../constants/schedule';
 import { getSchedule } from '../../../apis/schedule';
 import styles from './RecordTagDropDown.module.scss';
 
-const name = '건국대학교 3-1학기'; // 임시 지정
+const name = '김히얼'; // 임시 지정
 
 const RecordTagDropDown = () => {
   const { data } = useQuery<IScheduleElement[], Error>({

--- a/src/components/molecules/RecordTagDropDown/RecordTagDropDown.tsx
+++ b/src/components/molecules/RecordTagDropDown/RecordTagDropDown.tsx
@@ -38,20 +38,17 @@ const RecordTagDropDown = () => {
       <button
         className={`${styles.tagBtn} ${data !== undefined && data.length > 0 && styles.active}`}
         onClick={handleTagBtnClick}
-        aria-haspopup="listbox"
-        aria-expanded={isTagBtnClicked}
       >
         {tag !== '' ? tag : '태그'}
       </button>
       {isTagBtnClicked && (
-        <ul className={styles.tagsUl} role="listbox">
+        <ul className={styles.tagsUl}>
           {TAGS.map((name) => (
             <li
               key={name}
               className={styles.tagLi}
               onClick={() => handleLiClick(name)}
               role="option"
-              aria-selected={tag === name}
             >
               {name}
             </li>

--- a/src/components/molecules/RecordTagDropDown/RecordTagDropDown.tsx
+++ b/src/components/molecules/RecordTagDropDown/RecordTagDropDown.tsx
@@ -34,23 +34,31 @@ const RecordTagDropDown = () => {
   };
 
   return (
-    <span className={styles.wrapper}>
+    <div className={styles.wrapper}>
       <button
         className={`${styles.tagBtn} ${data !== undefined && data.length > 0 && styles.active}`}
         onClick={handleTagBtnClick}
+        aria-haspopup="listbox"
+        aria-expanded={isTagBtnClicked}
       >
         {tag !== '' ? tag : '태그'}
       </button>
       {isTagBtnClicked && (
-        <ul className={styles.tagsUl}>
+        <ul className={styles.tagsUl} role="listbox">
           {TAGS.map((name) => (
-            <li className={styles.tagLi} onClick={() => handleLiClick(name)}>
+            <li
+              key={name}
+              className={styles.tagLi}
+              onClick={() => handleLiClick(name)}
+              role="option"
+              aria-selected={tag === name}
+            >
               {name}
             </li>
           ))}
         </ul>
       )}
-    </span>
+    </div>
   );
 };
 

--- a/src/components/molecules/ScriptItem/ScriptItem.tsx
+++ b/src/components/molecules/ScriptItem/ScriptItem.tsx
@@ -9,11 +9,11 @@ interface IScriptProps {
 }
 const ScriptItem = ({ name, processedScript, lectureDate }: IScriptProps) => {
   return (
-    <div className={styles.postItContainer}>
-      <div className={styles.title}>{name}</div>
-      <div className={styles.content}>{processedScript[0]}...</div>
-      <span className={styles.date}>{formatScriptDate(lectureDate)}</span>
-    </div>
+    <article className={styles.postItContainer}>
+      <p className={styles.title}>{name}</p>
+      <p className={styles.content}>{processedScript[0]}...</p>
+      <p className={styles.date}>{formatScriptDate(lectureDate)}</p>
+    </article>
   );
 };
 export default ScriptItem;

--- a/src/components/molecules/ScriptToolTip/ScriptToolTip.module.scss
+++ b/src/components/molecules/ScriptToolTip/ScriptToolTip.module.scss
@@ -31,6 +31,7 @@
   justify-content: space-between;
   align-items: center;
   width: 100%;
+  min-width: 210px;
   height: 34px;
   padding: 12px;
   background-color: $white_FF;

--- a/src/components/molecules/ScriptToolTip/ScriptToolTip.module.scss
+++ b/src/components/molecules/ScriptToolTip/ScriptToolTip.module.scss
@@ -8,9 +8,6 @@
   background-color: $white_FF;
   border-radius: 8px;
   box-shadow: 0px 2px 20px 0px rgba(0, 0, 0, 0.1);
-  :last-child {
-    border: none;
-  }
 }
 .tooltipItem {
   display: flex;
@@ -21,5 +18,25 @@
   @include Medium_Body_16;
   color: $dark-font_33;
   border-bottom: 1px solid $light-bg_F2;
+  cursor: pointer;
+}
+.deleteBtnWrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 9px;
+}
+.deleteBtn {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  width: 100%;
+  height: 34px;
+  padding: 12px;
+  background-color: $white_FF;
+  border: 1px solid #ffd6d6;
+  border-radius: 8px;
+  @include SemiBold_Sub_14;
+  color: $brand-point;
   cursor: pointer;
 }

--- a/src/components/molecules/ScriptToolTip/ScriptToolTip.tsx
+++ b/src/components/molecules/ScriptToolTip/ScriptToolTip.tsx
@@ -25,25 +25,26 @@ const ScriptToolTip = ({ id }: IProps) => {
     setSelectedScriptId(null);
   };
 
-  return (
-    <div className={styles.container}>
-      {data?.map((lecture) => (
-        <div
-          className={styles.tooltipItem}
-          onClick={() => handleToolTipClick(lecture.id)}
-        >
-          {lecture.name}
-          <ScriptIcon />
-        </div>
-      ))}
-      {selectedScriptId !== null && (
-        <ScriptDetailModal
-          scriptId={selectedScriptId}
-          closeModal={handleCloseModal}
-        />
-      )}
-    </div>
-  );
+  if (data != null)
+    return (
+      <div className={styles.container}>
+        {data?.map((lecture) => (
+          <div
+            className={styles.tooltipItem}
+            onClick={() => handleToolTipClick(lecture.id)}
+          >
+            {lecture.name}
+            <ScriptIcon />
+          </div>
+        ))}
+        {selectedScriptId !== null && (
+          <ScriptDetailModal
+            scriptId={selectedScriptId}
+            closeModal={handleCloseModal}
+          />
+        )}
+      </div>
+    );
 };
 
 export default ScriptToolTip;

--- a/src/components/molecules/ScriptToolTip/ScriptToolTip.tsx
+++ b/src/components/molecules/ScriptToolTip/ScriptToolTip.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import ScriptDetailModal from '../../templates/modals/ScriptDetailModal/ScriptDetailModal';
 import { getLectureByScheduleElement } from '../../../apis/schedule';
 import ScriptIcon from '../../../assets/images/nav/my-script-inactive.svg?react';
+import TrashCan from '../../../assets/images/orange-trash-can.svg?react';
 import styles from './ScriptToolTip.module.scss';
 
 interface IProps {
@@ -25,26 +26,33 @@ const ScriptToolTip = ({ id }: IProps) => {
     setSelectedScriptId(null);
   };
 
-  if (data != null)
-    return (
-      <div className={styles.container}>
-        {data?.map((lecture) => (
-          <div
-            className={styles.tooltipItem}
-            onClick={() => handleToolTipClick(lecture.id)}
-          >
-            {lecture.name}
-            <ScriptIcon />
-          </div>
-        ))}
-        {selectedScriptId !== null && (
-          <ScriptDetailModal
-            scriptId={selectedScriptId}
-            closeModal={handleCloseModal}
-          />
-        )}
+  const handleDeleteBtnClick = () => {};
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.deleteBtnWrapper}>
+        <button className={styles.deleteBtn} onClick={handleDeleteBtnClick}>
+          이 수업 삭제하기
+          <TrashCan />
+        </button>
       </div>
-    );
+      {data?.map((lecture) => (
+        <div
+          className={styles.tooltipItem}
+          onClick={() => handleToolTipClick(lecture.id)}
+        >
+          {lecture.name}
+          <ScriptIcon />
+        </div>
+      ))}
+      {selectedScriptId !== null && (
+        <ScriptDetailModal
+          scriptId={selectedScriptId}
+          closeModal={handleCloseModal}
+        />
+      )}
+    </div>
+  );
 };
 
 export default ScriptToolTip;

--- a/src/components/molecules/ScriptToolTip/ScriptToolTip.tsx
+++ b/src/components/molecules/ScriptToolTip/ScriptToolTip.tsx
@@ -1,21 +1,38 @@
 import { useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import ScriptDetailModal from '../../templates/modals/ScriptDetailModal/ScriptDetailModal';
-import { getLectureByScheduleElement } from '../../../apis/schedule';
+import {
+  deleteScheduleElement,
+  getLectureByScheduleElement,
+} from '../../../apis/schedule';
 import ScriptIcon from '../../../assets/images/nav/my-script-inactive.svg?react';
 import TrashCan from '../../../assets/images/orange-trash-can.svg?react';
 import styles from './ScriptToolTip.module.scss';
 
 interface IProps {
   id: number;
+  scheduleName: string;
 }
 
-const ScriptToolTip = ({ id }: IProps) => {
+const name = '김히얼'; //임시
+
+const ScriptToolTip = ({ id, scheduleName }: IProps) => {
   const [selectedScriptId, setSelectedScriptId] = useState<string | null>(null);
+  const queryClient = useQueryClient();
 
   const { data } = useQuery({
     queryKey: ['tooltip', id],
     queryFn: () => getLectureByScheduleElement(id),
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: number) => deleteScheduleElement(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['schedule', name] });
+    },
+    onError: () => {
+      alert('시간표 삭제를 실패했습니다.');
+    },
   });
 
   const handleToolTipClick = (scriptId: string) => {
@@ -26,7 +43,11 @@ const ScriptToolTip = ({ id }: IProps) => {
     setSelectedScriptId(null);
   };
 
-  const handleDeleteBtnClick = () => {};
+  const handleDeleteBtnClick = () => {
+    if (window.confirm(`'${scheduleName}' 수업을 삭제하시겠습니까?`)) {
+      deleteMutation.mutate(id);
+    }
+  };
 
   return (
     <div className={styles.container}>

--- a/src/components/molecules/TimeTableItem/TimeTableItem.module.scss
+++ b/src/components/molecules/TimeTableItem/TimeTableItem.module.scss
@@ -39,4 +39,5 @@
   position: absolute;
   left: var(--schedule-left);
   top: var(--schedule-top);
+  z-index: 5;
 }

--- a/src/components/molecules/TimeTableItem/TimeTableItem.tsx
+++ b/src/components/molecules/TimeTableItem/TimeTableItem.tsx
@@ -62,7 +62,7 @@ const TimeTableItem = ({
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}
         >
-          <ScriptToolTip id={id} />
+          <ScriptToolTip id={id} scheduleName={name} />
         </span>
       )}
     </>

--- a/src/components/organisms/AddScheduleForm/AddScheduleForm.tsx
+++ b/src/components/organisms/AddScheduleForm/AddScheduleForm.tsx
@@ -95,6 +95,7 @@ const AddScheduleForm = ({ onClose }: IProps) => {
     mutationFn: (data: IScheduleElementDTO) => addScheduleElement(data),
     onSuccess: () => {
       onClose();
+      const name = '김히얼'; // 동적 할당 구현 예정
       queryClient.invalidateQueries({ queryKey: ['schedule', name] });
     },
     onError: () => {
@@ -104,7 +105,6 @@ const AddScheduleForm = ({ onClose }: IProps) => {
 
   const handleSubmit = () => {
     if (isFormValid) {
-      console.log('Lecture added:', lectureInfo);
       const formattedData = transformToScheduleElementDTO(lectureInfo);
       postMutation.mutate(formattedData);
     }

--- a/src/components/organisms/AddScheduleForm/AddScheduleForm.tsx
+++ b/src/components/organisms/AddScheduleForm/AddScheduleForm.tsx
@@ -10,14 +10,19 @@ import {
 import {
   getIsAddScheduleFormValid,
   getIsTimeValid,
+  IScheduleElementDTO,
+  transformToScheduleElementDTO,
 } from '../../../utils/schedule';
 import styles from './AddScheduleForm.module.scss';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { addScheduleElement } from '../../../apis/schedule';
 
 interface IProps {
   onClose: () => void;
 }
 
 const AddScheduleForm = ({ onClose }: IProps) => {
+  const queryClient = useQueryClient();
   const [lectureInfo, setLectureInfo] =
     useState<LectureInfo>(initialLectureInfo);
   const [isTimeValid, setIsTimeValid] = useState(false);
@@ -86,10 +91,22 @@ const AddScheduleForm = ({ onClose }: IProps) => {
     setLectureInfo((prevState) => ({ ...prevState, day }));
   };
 
+  const postMutation = useMutation({
+    mutationFn: (data: IScheduleElementDTO) => addScheduleElement(data),
+    onSuccess: () => {
+      onClose();
+      queryClient.invalidateQueries({ queryKey: ['schedule', name] });
+    },
+    onError: () => {
+      alert('강의 추가를 실패했습니다.');
+    },
+  });
+
   const handleSubmit = () => {
     if (isFormValid) {
       console.log('Lecture added:', lectureInfo);
-      onClose();
+      const formattedData = transformToScheduleElementDTO(lectureInfo);
+      postMutation.mutate(formattedData);
     }
   };
 

--- a/src/components/organisms/headers/RecordHeader/RecordHeader.tsx
+++ b/src/components/organisms/headers/RecordHeader/RecordHeader.tsx
@@ -46,11 +46,11 @@ const RecordHeader = ({ stopRecordingAndDisconnectSocket }: IProps) => {
 
   return (
     <header className={styles.container}>
-      <span className={styles.linkContainer}>
+      <div className={styles.linkContainer}>
         <Link to="/home">
           <Back />
         </Link>
-      </span>
+      </div>
       <div className={styles.titleContainer}>
         <h1 className={styles.title}>{title}</h1>
         <RecordTagDropDown />

--- a/src/components/organisms/headers/TestHeader/TestHeader.tsx
+++ b/src/components/organisms/headers/TestHeader/TestHeader.tsx
@@ -48,18 +48,18 @@ const TestHeader = ({ handleSubmit, showResults }: IProps) => {
 
   return (
     <header className={styles.container}>
-      <span className={styles.leftContainer}>
+      <div className={styles.leftContainer}>
         <Link to="/home/test-make">
           <Back />
         </Link>
-      </span>
+      </div>
       <h1 className={styles.title}>{TEST_TITLE}</h1>
-      <span className={styles.rightContainer}>
+      <div className={styles.rightContainer}>
         <p className={styles.timer}>{formatTimer(seconds)}</p>
         <button className={styles.quitBtn} onClick={handleClickQuitBtn}>
           종료
         </button>
-      </span>
+      </div>
       {isModalOpen && (
         <TestModal title={TEST_TITLE} handleSubmit={handleSubmit} />
       )}

--- a/src/components/templates/modals/RecordModal/RecordModal.module.scss
+++ b/src/components/templates/modals/RecordModal/RecordModal.module.scss
@@ -69,14 +69,12 @@
     outline: none;
   }
 }
-
 .modalActions {
   display: flex;
   width: 100%;
   justify-content: space-between;
   margin-top: 30px;
 }
-
 .modalClose {
   background-color: $light-bg_F2;
   border: 1px solid $light-bg_F2;
@@ -131,4 +129,5 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  cursor: pointer;
 }

--- a/src/components/templates/modals/RecordModal/RecordModal.tsx
+++ b/src/components/templates/modals/RecordModal/RecordModal.tsx
@@ -13,7 +13,7 @@ interface IProps {
   handleQuit: () => void; // 타이머, 녹음, 소켓 연결 종료
 }
 
-const name = '건국대학교 3-1학기'; // 임시 지정
+const name = '김히얼'; // 임시 지정
 
 const RecordModal = ({ handleQuit }: IProps) => {
   const navigate = useNavigate();

--- a/src/components/templates/modals/RecordModal/RecordModal.tsx
+++ b/src/components/templates/modals/RecordModal/RecordModal.tsx
@@ -89,9 +89,11 @@ const RecordModal = ({ handleQuit }: IProps) => {
               onChange={handleChange}
               readOnly
             />
-            <span className={styles.arrow} onClick={handleClickArrow}>
-              {isTagClicked ? <Up /> : <Down />}
-            </span>
+            {TAGS.length > 0 && (
+              <div className={styles.arrow} onClick={handleClickArrow}>
+                {isTagClicked ? <Up /> : <Down />}
+              </div>
+            )}
           </div>
         </div>
         {isTagClicked && (

--- a/src/components/templates/modals/ScriptDetailModal/ScriptDetailModal.module.scss
+++ b/src/components/templates/modals/ScriptDetailModal/ScriptDetailModal.module.scss
@@ -14,6 +14,7 @@
   height: 100dvh;
   padding: 20px;
   background: rgba(0, 0, 0, 0.1);
+  z-index: 10;
 }
 .contentContainer {
   position: relative;

--- a/src/components/templates/modals/ScriptDetailModal/ScriptDetailModal.tsx
+++ b/src/components/templates/modals/ScriptDetailModal/ScriptDetailModal.tsx
@@ -58,11 +58,16 @@ const ScriptDetailModal = ({ scriptId, closeModal }: IProps) => {
   }, [isPlaying]);
 
   return createPortal(
-    <div className={styles.overlay} onClick={closeModal}>
+    <div
+      className={styles.overlay}
+      onClick={closeModal}
+      onMouseEnter={(e) => e.stopPropagation()}
+      onMouseLeave={(e) => e.stopPropagation()}
+    >
       <article className={styles.contentContainer} onClick={handleContentClick}>
-        <button className={styles.xBtn} onClick={closeModal}>
+        <span className={styles.xBtn} onClick={closeModal}>
           <X />
-        </button>
+        </span>
         <p className={styles.title}>{data?.name}</p>
         <div className={styles.playBox}>
           <div className={styles.playBtn} onClick={handlePlayClick}>

--- a/src/components/templates/modals/ScriptDetailModal/ScriptDetailModal.tsx
+++ b/src/components/templates/modals/ScriptDetailModal/ScriptDetailModal.tsx
@@ -60,14 +60,14 @@ const ScriptDetailModal = ({ scriptId, closeModal }: IProps) => {
   return createPortal(
     <div className={styles.overlay} onClick={closeModal}>
       <article className={styles.contentContainer} onClick={handleContentClick}>
-        <span className={styles.xBtn} onClick={closeModal}>
+        <button className={styles.xBtn} onClick={closeModal}>
           <X />
-        </span>
+        </button>
         <p className={styles.title}>{data?.name}</p>
         <div className={styles.playBox}>
-          <span className={styles.playBtn} onClick={handlePlayClick}>
+          <div className={styles.playBtn} onClick={handlePlayClick}>
             {isPlaying ? <Pause /> : <Play />}
-          </span>
+          </div>
           <p className={styles.time}>{formatTimer(time)}</p>
         </div>
         <p className={styles.textBox}>{data?.processedScript.join(' ')}</p>

--- a/src/constants/schedule.ts
+++ b/src/constants/schedule.ts
@@ -48,3 +48,13 @@ export const initialLectureInfo: LectureInfo = {
   endHour: '00',
   endMinute: '00',
 };
+
+export const daysObject = {
+  월: 'MON',
+  화: 'TUE',
+  수: 'WED',
+  목: 'THU',
+  금: 'FRI',
+  토: 'SAT',
+  일: 'SUN',
+};

--- a/src/pages/Auth/AuthForm/AuthForm.tsx
+++ b/src/pages/Auth/AuthForm/AuthForm.tsx
@@ -129,7 +129,7 @@ const AuthForm = ({
               </button>
             </label>
             {title === '로그인' && (
-              <span className={styles.checkboxContainer}>
+              <div className={styles.checkboxContainer}>
                 <input
                   type="checkbox"
                   id="remember"
@@ -138,7 +138,7 @@ const AuthForm = ({
                 <label className={styles.checkBoxLabel} htmlFor="remember">
                   로그인 유지하기
                 </label>
-              </span>
+              </div>
             )}
           </div>
           {title === '새 계정' && (

--- a/src/pages/Landing/Landing.tsx
+++ b/src/pages/Landing/Landing.tsx
@@ -45,29 +45,29 @@ const Landing = () => {
         <article className={styles.function}>
           <div className={styles.functionImg}></div>
           <h3>청각장애학우 지원</h3>
-          <span className={styles.descriptionContainer}>
+          <div className={styles.descriptionContainer}>
             <p>강의 중, 조별과제, 회의 상황에서</p>
             <p>실시간 음성인식 자막을 통해</p>
             <p>빠르게 이해하고 소통할 수 있어요</p>
-          </span>
+          </div>
         </article>
         <article className={styles.function}>
           <div className={styles.functionImg}></div>
           <h3>학습효율 향상</h3>
-          <span className={styles.descriptionContainer}>
+          <div className={styles.descriptionContainer}>
             <p>녹음 스크립트가 준비되었다면</p>
             <p>테스트 자동 생성 기능으로</p>
             <p>어려운 부분을 찾아 복습해보세요</p>
-          </span>
+          </div>
         </article>
         <article className={styles.function}>
           <div className={styles.functionImg}></div>
           <h3>교육적 불평등 완화</h3>
-          <span className={styles.descriptionContainer}>
+          <div className={styles.descriptionContainer}>
             <p>너무 빠르거나 익숙하지 않아서,</p>
             <p>곧바로 이해하기 어려운 수업도</p>
             <p>여러 번 읽고 깊게 생각해보세요</p>
-          </span>
+          </div>
         </article>
       </section>
       <section className={styles.highLight}>

--- a/src/pages/Main/MyScript/MyScript.tsx
+++ b/src/pages/Main/MyScript/MyScript.tsx
@@ -42,14 +42,14 @@ const MyScript = () => {
       ) : (
         <div className={styles.scriptContainer}>
           {data?.map((script) => (
-            <span
+            <div
               key={script.id}
               onClick={() => {
                 handleScriptClick(script.id);
               }}
             >
               <ScriptItem {...script} />
-            </span>
+            </div>
           ))}
         </div>
       )}

--- a/src/pages/Main/TestMake/TestMake.tsx
+++ b/src/pages/Main/TestMake/TestMake.tsx
@@ -40,7 +40,7 @@ const TestMake = () => {
         {data && data.length > 0 ? (
           <section className={styles.scriptsContainer}>
             {data.map((script) => (
-              <span
+              <div
                 key={script.id}
                 className={`${script.id === lectureId ? styles.selectedScript : styles.scriptWrapper}`}
                 onClick={() => {
@@ -48,7 +48,7 @@ const TestMake = () => {
                 }}
               >
                 <ScriptItem {...script} />
-              </span>
+              </div>
             ))}
           </section>
         ) : (

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.module.scss
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.module.scss
@@ -10,9 +10,6 @@
   padding: 10px 30px;
   border-radius: 12px;
 }
-.tableContainer {
-  // margin: 10px 30px;
-}
 .dayOfWeekRow {
   display: flex;
   justify-content: space-between;
@@ -61,10 +58,6 @@
   background-color: $light-bg_F9;
   border-right: 1px solid $light-bg_E5;
 }
-.lastCell {
-  background-color: transparent !important;
-  // border: none;
-  text-align: center;
-  border-right: 0 !important;
-  border-left: 0 !important;
+.lastRow {
+  border-bottom: 1px solid $light-bg_E5;
 }

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
@@ -8,7 +8,7 @@ import {
 import { getSchedule } from '../../../../apis/schedule';
 import styles from './WeeklyTimeTable.module.scss';
 
-const name = '건국대학교 3-1학기'; // 임시 지정
+const name = '김히얼'; // 임시 지정
 
 const WeeklyTimeTable = () => {
   const { data } = useQuery<IScheduleElement[], Error>({

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
@@ -5,8 +5,8 @@ import {
   IScheduleElement,
   TIMELIST,
 } from '../../../../constants/schedule';
-import styles from './WeeklyTimeTable.module.scss';
 import { getSchedule } from '../../../../apis/schedule';
+import styles from './WeeklyTimeTable.module.scss';
 
 const name = '건국대학교 3-1학기'; // 임시 지정
 
@@ -28,14 +28,13 @@ const WeeklyTimeTable = () => {
         {TIMELIST.map((time, index) => (
           <div className={styles.timeRow} key={index}>
             <span className={styles.time}>{time}</span>
-            {daysOfWeek.map((day) => (
-              <div
-                className={`${styles.daytime} ${
-                  index === TIMELIST.length - 1 ? styles.lastCell : ''
-                }`}
-                key={day}
-              ></div>
-            ))}
+            {index !== TIMELIST.length - 1 &&
+              daysOfWeek.map((day) => (
+                <div
+                  className={`${styles.daytime} ${index === TIMELIST.length - 2 && styles.lastRow}`}
+                  key={day}
+                />
+              ))}
           </div>
         ))}
       </div>

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
@@ -27,7 +27,7 @@ const WeeklyTimeTable = () => {
       <div className={styles.tableBox}>
         {TIMELIST.map((time, index) => (
           <div className={styles.timeRow} key={index}>
-            <span className={styles.time}>{time}</span>
+            <p className={styles.time}>{time}</p>
             {index !== TIMELIST.length - 1 &&
               daysOfWeek.map((day) => (
                 <div

--- a/src/utils/schedule.ts
+++ b/src/utils/schedule.ts
@@ -1,4 +1,9 @@
-import { DayOfWeek, LectureInfo } from '../constants/schedule';
+import {
+  ColorKey,
+  DayOfWeek,
+  daysObject,
+  LectureInfo,
+} from '../constants/schedule';
 
 const DAYMAP: Record<DayOfWeek, number> = {
   SUN: 0,
@@ -82,4 +87,39 @@ export const getIsAddScheduleFormValid = ({
       Number(endMinute),
     );
   return isValid;
+};
+
+// 요일 한글 -> 대문자 영어 변환
+const getDayOfWeek = (day: string) => {
+  return daysObject[day as keyof typeof daysObject] || day;
+};
+
+// 시간 ISO 변환
+const getFormattedTime = (hour: string, minute: string) => {
+  const date = new Date();
+  date.setHours(parseInt(hour), parseInt(minute), 0, 0);
+  const dateString = date.toISOString().split('T')[0];
+  const timeString = `${hour.padStart(2, '0')}:${minute.padStart(2, '0')}:00`;
+  return `${dateString}T${timeString}`;
+};
+
+export interface IScheduleElementDTO {
+  name: string;
+  location: string;
+  dayOfWeek: string;
+  startTime: string;
+  endTime: string;
+  color: ColorKey;
+}
+
+export const transformToScheduleElementDTO = (lectureData: LectureInfo) => {
+  const transformedData = {
+    name: lectureData.title,
+    location: lectureData.location,
+    dayOfWeek: getDayOfWeek(lectureData.day),
+    startTime: getFormattedTime(lectureData.startHour, lectureData.startMinute),
+    endTime: getFormattedTime(lectureData.endHour, lectureData.endMinute),
+    color: lectureData.lectureColor,
+  };
+  return transformedData;
 };


### PR DESCRIPTION
## 요약 (Summary)

시간표 추가/삭제 API 연결 및 자잘한 리팩토링

## 변경 사항 (Changes)

**1. 시간표 추가 API 연결**
- 색상 미선택시 빨간색으로 기본 선택됩니다. 초기 표시도 빨간색에 표시되어있습니다.
- API 요청 성공 후 `queryClient.invalidateQueries({...})`로 업데이트된 데이터를 다시 불러오도록 했습니다.

**2. 시간표 삭제 버튼 추가 및 API 연결** 
- ToolTip 컴포넌트에 삭제 버튼 추가
- API 요청 성공 후 `queryClient.invalidateQueries({...})`로 업데이트된 데이터를 다시 불러오도록 했습니다.

**3. 자잘한 리팩토링**
- span 태그 일부분 div 태그로 전환
- !important 제거
 
레퍼런스 : https://brunch.co.kr/@skykamja24/267



## 리뷰 요구사항

- post, delete 등 데이터 변경을 요구하는 요청 후에는 `mutation`의 `onSuccess` 안에 `queriClient.invalidateQuries`를 써서 변경된 데이터를 업데이트할 수 있습니다!
- 현재 API response 타입을 각 API마다 직접 Response 타입을 만들어서 할당하고 있는데, API Response들이
```
{
  status: string;
  msg: string;
  object: T; // 이부분만 변경됨 
  success: boolean;
}
```
이 형태로 공통적으로 오고 있어서 API Response 타입 부분을 타입스크립트의 제네릭을 사용해서 object 부분의 타입만 지정할 
수 있도록 제네릭 타입을 만들어서 체계를 만들 수 있을 것 같습니다. 
@koeunbeee 님께서 하고싶으시면 작업 해보셔도 좋은데 TS 아무래도 처음 써보시니까 어려우시면 제가 이부분 작업해서 알려드리겠습니다. 

## 확인 방법 (선택)

![image](https://github.com/user-attachments/assets/942c7d2b-d31a-40f3-b38e-51ee8b7ac56e)
