### PR TITLE
Feat: 유저 이름 불러오기

### DIFF
--- a/src/apis/schedule.ts
+++ b/src/apis/schedule.ts
@@ -77,7 +77,10 @@ interface IPOSTScheduleElementResponse {
   success: boolean;
 }
 
-export const addScheduleElement = async (inputData: IScheduleElementDTO) => {
+export const addScheduleElement = async (
+  inputData: IScheduleElementDTO,
+  name: string,
+) => {
   const token = getToken();
   try {
     const res = await fetch(`${API_URL}/api/v1/schedule/addElement`, {
@@ -88,7 +91,7 @@ export const addScheduleElement = async (inputData: IScheduleElementDTO) => {
       },
       body: JSON.stringify({
         scheduleDTO: {
-          name: '김히얼', // 동적 할당 구현 예정
+          name,
         },
         scheduleElementDTO: inputData,
       }),
@@ -100,7 +103,10 @@ export const addScheduleElement = async (inputData: IScheduleElementDTO) => {
   }
 };
 
-export const deleteScheduleElement = async (scheduleElementId: number) => {
+export const deleteScheduleElement = async (
+  scheduleElementId: number,
+  name: string,
+) => {
   const token = getToken();
   try {
     const res = await fetch(`${API_URL}/api/v1/schedule/deleteElement`, {
@@ -111,7 +117,7 @@ export const deleteScheduleElement = async (scheduleElementId: number) => {
       },
       body: JSON.stringify({
         scheduleDTO: {
-          name: '김히얼', // 동적 할당 구현 예정
+          name,
         },
         scheduleElementDTO: {
           id: scheduleElementId,

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -1,0 +1,39 @@
+import { API_URL, getToken } from '.';
+
+interface IGetUserInfoResponse {
+  status: string;
+  msg: string;
+  object: IUserInfo;
+  success: boolean;
+}
+
+interface IUserInfo {
+  userId: string;
+  userName: string;
+  userEmail: string;
+  userPassword: string;
+  userRole: string;
+  userIsOAuth: boolean;
+  userOAuthType: string;
+  userSchool: string;
+  userMajor: string;
+  userGrade: string;
+  userSavedLectures: any; // 임시 타입
+  userSchedule: any; // 임시 타입
+  userUsePurpose: any; // 임시 타입
+}
+
+export const getUserInfo = async () => {
+  const token = getToken();
+  try {
+    const res = await fetch(`${API_URL}/api/v1/user/present-user`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    const data: IGetUserInfoResponse = await res.json();
+    return data.object;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/apis/user.ts
+++ b/src/apis/user.ts
@@ -7,7 +7,7 @@ interface IGetUserInfoResponse {
   success: boolean;
 }
 
-interface IUserInfo {
+export interface IUserInfo {
   userId: string;
   userName: string;
   userEmail: string;

--- a/src/components/molecules/RecordTagDropDown/RecordTagDropDown.tsx
+++ b/src/components/molecules/RecordTagDropDown/RecordTagDropDown.tsx
@@ -4,13 +4,13 @@ import useRecordModalStore from '../../../store/useRecordModalStore';
 import { IScheduleElement } from '../../../constants/schedule';
 import { getSchedule } from '../../../apis/schedule';
 import styles from './RecordTagDropDown.module.scss';
-
-const name = '김히얼'; // 임시 지정
+import { useUserInfoStore } from '../../../store/userUserInfoStore';
 
 const RecordTagDropDown = () => {
+  const { userInfo } = useUserInfoStore();
   const { data } = useQuery<IScheduleElement[], Error>({
-    queryKey: ['schedule', name],
-    queryFn: () => getSchedule(name),
+    queryKey: ['schedule', userInfo.userName],
+    queryFn: () => getSchedule(userInfo.userName),
   });
 
   const [isTagBtnClicked, setIsTagBtnClicked] = useState(false);

--- a/src/components/molecules/ScriptToolTip/ScriptToolTip.tsx
+++ b/src/components/molecules/ScriptToolTip/ScriptToolTip.tsx
@@ -8,17 +8,18 @@ import {
 import ScriptIcon from '../../../assets/images/nav/my-script-inactive.svg?react';
 import TrashCan from '../../../assets/images/orange-trash-can.svg?react';
 import styles from './ScriptToolTip.module.scss';
+import { useUserInfoStore } from '../../../store/userUserInfoStore';
 
 interface IProps {
   id: number;
   scheduleName: string;
 }
 
-const name = '김히얼'; //임시
-
 const ScriptToolTip = ({ id, scheduleName }: IProps) => {
   const [selectedScriptId, setSelectedScriptId] = useState<string | null>(null);
   const queryClient = useQueryClient();
+
+  const { userInfo } = useUserInfoStore();
 
   const { data } = useQuery({
     queryKey: ['tooltip', id],
@@ -26,7 +27,7 @@ const ScriptToolTip = ({ id, scheduleName }: IProps) => {
   });
 
   const deleteMutation = useMutation({
-    mutationFn: (id: number) => deleteScheduleElement(id),
+    mutationFn: (id: number) => deleteScheduleElement(id, userInfo.userName),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['schedule', name] });
     },

--- a/src/components/organisms/AddScheduleForm/AddScheduleForm.tsx
+++ b/src/components/organisms/AddScheduleForm/AddScheduleForm.tsx
@@ -16,6 +16,7 @@ import {
 import styles from './AddScheduleForm.module.scss';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { addScheduleElement } from '../../../apis/schedule';
+import { useUserInfoStore } from '../../../store/userUserInfoStore';
 
 interface IProps {
   onClose: () => void;
@@ -32,6 +33,8 @@ const AddScheduleForm = ({ onClose }: IProps) => {
   const startMinuteRef = useRef<HTMLInputElement | null>(null);
   const endHourRef = useRef<HTMLInputElement | null>(null);
   const endMinuteRef = useRef<HTMLInputElement | null>(null);
+
+  const { userInfo } = useUserInfoStore();
 
   useEffect(() => {
     const isFormValid = getIsAddScheduleFormValid(lectureInfo);
@@ -92,11 +95,13 @@ const AddScheduleForm = ({ onClose }: IProps) => {
   };
 
   const postMutation = useMutation({
-    mutationFn: (data: IScheduleElementDTO) => addScheduleElement(data),
+    mutationFn: (data: IScheduleElementDTO) =>
+      addScheduleElement(data, userInfo.userName),
     onSuccess: () => {
       onClose();
-      const name = '김히얼'; // 동적 할당 구현 예정
-      queryClient.invalidateQueries({ queryKey: ['schedule', name] });
+      queryClient.invalidateQueries({
+        queryKey: ['schedule', userInfo.userName],
+      });
     },
     onError: () => {
       alert('강의 추가를 실패했습니다.');

--- a/src/components/organisms/navigators/MainNav/MainNav.module.scss
+++ b/src/components/organisms/navigators/MainNav/MainNav.module.scss
@@ -26,6 +26,7 @@
 }
 .userName {
   @include Medium_Body_16;
+  color: #232323;
 }
 .searchBar {
   display: flex;

--- a/src/components/organisms/navigators/MainNav/MainNav.tsx
+++ b/src/components/organisms/navigators/MainNav/MainNav.tsx
@@ -9,15 +9,12 @@ import TestMakeInactive from '../../../../assets/images/nav/test-make-inactive.s
 import TrashCanActive from '../../../../assets/images/nav/trash-can-active.svg?react';
 import TrashCanInactive from '../../../../assets/images/nav/trash-can-inactive.svg?react';
 import styles from './MainNav.module.scss';
-import { useQuery } from '@tanstack/react-query';
-import { getUserInfo } from '../../../../apis/user';
+import { useUserInfoStore } from '../../../../store/userUserInfoStore';
 
 const MainNav = () => {
-  const { data } = useQuery({
-    queryKey: ['user'],
-    queryFn: getUserInfo,
-  });
-  const USERNAME = data?.userName;
+  const { userInfo } = useUserInfoStore();
+  const USERNAME = userInfo.userName;
+
   return (
     <nav className={styles.container}>
       <div className={styles.userProfile}>

--- a/src/components/organisms/navigators/MainNav/MainNav.tsx
+++ b/src/components/organisms/navigators/MainNav/MainNav.tsx
@@ -9,14 +9,20 @@ import TestMakeInactive from '../../../../assets/images/nav/test-make-inactive.s
 import TrashCanActive from '../../../../assets/images/nav/trash-can-active.svg?react';
 import TrashCanInactive from '../../../../assets/images/nav/trash-can-inactive.svg?react';
 import styles from './MainNav.module.scss';
+import { useQuery } from '@tanstack/react-query';
+import { getUserInfo } from '../../../../apis/user';
 
 const MainNav = () => {
-  const USERNAME = 'UserName'; // 임시 지정
+  const { data } = useQuery({
+    queryKey: ['user'],
+    queryFn: getUserInfo,
+  });
+  const USERNAME = data?.userName;
   return (
     <nav className={styles.container}>
       <div className={styles.userProfile}>
         <div className={styles.profileImage}></div>
-        <p className={styles.useName}>{USERNAME}</p>
+        <p className={styles.userName}>{USERNAME}</p>
       </div>
       <span className={styles.searchIcon}>
         <Search />

--- a/src/components/templates/modals/RecordModal/RecordModal.tsx
+++ b/src/components/templates/modals/RecordModal/RecordModal.tsx
@@ -8,12 +8,11 @@ import Down from '../../../../assets/images/arrow/down-arrow.svg?react';
 import { IScheduleElement } from '../../../../constants/schedule';
 import { getSchedule } from '../../../../apis/schedule';
 import styles from './RecordModal.module.scss';
+import { useUserInfoStore } from '../../../../store/userUserInfoStore';
 
 interface IProps {
   handleQuit: () => void; // 타이머, 녹음, 소켓 연결 종료
 }
-
-const name = '김히얼'; // 임시 지정
 
 const RecordModal = ({ handleQuit }: IProps) => {
   const navigate = useNavigate();
@@ -21,9 +20,11 @@ const RecordModal = ({ handleQuit }: IProps) => {
   const [localData, setLocalData] = useState(recordData);
   const [isTagClicked, setIsTagClicked] = useState(false);
 
+  const { userInfo } = useUserInfoStore();
+
   const { data } = useQuery<IScheduleElement[], Error>({
-    queryKey: ['schedule', name],
-    queryFn: () => getSchedule(name),
+    queryKey: ['schedule', userInfo.userName],
+    queryFn: () => getSchedule(userInfo.userName),
   });
   const TAGS = useMemo(() => {
     if (!data) return [];

--- a/src/pages/Main/TimeTable/TimeTable.tsx
+++ b/src/pages/Main/TimeTable/TimeTable.tsx
@@ -2,9 +2,11 @@ import { useState } from 'react';
 import styles from './TimeTable.module.scss';
 import WeeklyTimeTable from './WeeklyTimeTable/WeeklyTimeTable';
 import AddScheduleForm from '../../../components/organisms/AddScheduleForm/AddScheduleForm';
+import { useUserInfoStore } from '../../../store/userUserInfoStore';
 
 const TimeTable = () => {
   const [isOpen, setIsOpen] = useState(false);
+  const { userInfo } = useUserInfoStore();
 
   const handleOpenModal = () => {
     setIsOpen(!isOpen);
@@ -16,7 +18,7 @@ const TimeTable = () => {
     <div className={styles.wholeWrapper}>
       <div className={styles.headerContainer}>
         <div className={styles.dateBox}>
-          <h3 className={styles.title}>Username의 시간표</h3>
+          <h3 className={styles.title}>{`${userInfo.userName}의 시간표`}</h3>
         </div>
         <button className={styles.addScheduleBtn} onClick={handleOpenModal}>
           강의 추가 +

--- a/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
+++ b/src/pages/Main/TimeTable/WeeklyTimeTable/WeeklyTimeTable.tsx
@@ -7,13 +7,14 @@ import {
 } from '../../../../constants/schedule';
 import { getSchedule } from '../../../../apis/schedule';
 import styles from './WeeklyTimeTable.module.scss';
-
-const name = '김히얼'; // 임시 지정
+import { useUserInfoStore } from '../../../../store/userUserInfoStore';
 
 const WeeklyTimeTable = () => {
+  const { userInfo } = useUserInfoStore();
+
   const { data } = useQuery<IScheduleElement[], Error>({
-    queryKey: ['schedule', name],
-    queryFn: () => getSchedule(name),
+    queryKey: ['schedule', userInfo.userName],
+    queryFn: () => getSchedule(userInfo.userName),
   });
   return (
     <div className={styles.table}>

--- a/src/pages/PrivateRoute.tsx
+++ b/src/pages/PrivateRoute.tsx
@@ -1,11 +1,26 @@
 import { Navigate } from 'react-router-dom';
 import { checkAuthentication } from '../utils/auth';
+import { useUserInfoStore } from '../store/userUserInfoStore';
+import { useQuery } from '@tanstack/react-query';
+import { getUserInfo } from '../apis/user';
+import { useEffect } from 'react';
 
 interface IProps {
   element: React.ReactElement;
 }
 
 const PrivateRoute = ({ element }: IProps) => {
+  const { data } = useQuery({
+    queryKey: ['user'],
+    queryFn: getUserInfo,
+  });
+  const { setUserInfo } = useUserInfoStore();
+  useEffect(() => {
+    if (data != null) {
+      setUserInfo(data);
+    }
+  }, [data]);
+
   // 로그인 상태 확인
   const isAuthenticated = checkAuthentication();
 

--- a/src/pages/PrivateRoute.tsx
+++ b/src/pages/PrivateRoute.tsx
@@ -13,6 +13,7 @@ const PrivateRoute = ({ element }: IProps) => {
   const { data } = useQuery({
     queryKey: ['user'],
     queryFn: getUserInfo,
+    staleTime: 5 * 60 * 1000,
   });
   const { setUserInfo } = useUserInfoStore();
   useEffect(() => {

--- a/src/store/userUserInfoStore.ts
+++ b/src/store/userUserInfoStore.ts
@@ -1,0 +1,28 @@
+import create from 'zustand';
+import { IUserInfo } from '../apis/user';
+
+interface IUserStoreState {
+  userInfo: IUserInfo;
+  setUserInfo: (userInfo: IUserInfo) => void;
+}
+
+const initialUserInfo = {
+  userId: '',
+  userName: '',
+  userEmail: '',
+  userPassword: '',
+  userRole: '',
+  userIsOAuth: false,
+  userOAuthType: '',
+  userSchool: '',
+  userMajor: '',
+  userGrade: '',
+  userSavedLectures: [], // 임시
+  userSchedule: [], // 임시
+  userUsePurpose: null, // 임시
+};
+
+export const useUserInfoStore = create<IUserStoreState>((set) => ({
+  userInfo: initialUserInfo,
+  setUserInfo: (newUserInfo: IUserInfo) => set({ userInfo: newUserInfo }),
+}));


### PR DESCRIPTION
## 요약 (Summary)

유저 이름 불러오는 API 연결

## 변경 사항 (Changes)

- 유저 이름 불러와서 왼쪽 카테고리 nav 상단에 띄우기
- 시간표에 username의 시간표에 실제 유저 이름 할당
- 유저 정보를 전역 상태로 관리해서 시간표의 name에 들어가는 유저 이름에 할당
  - `useUserInfoStore`를 만들어서 `Private Route`에서 유저 정보 세팅

## 리뷰 요구사항

- `PrivateRoute.tsx`에서 로그인 해야 들어갈 수 있는 페이지에서 유저 정보 세팅하고있으니 확인 바랍니다.

## 확인 방법 (선택)

![image](https://github.com/user-attachments/assets/e3ab3a76-29ed-476c-9509-b5eb98805d39)

